### PR TITLE
Add safety cap to ComicVine issue pagination

### DIFF
--- a/app/Services/ComicVineService.php
+++ b/app/Services/ComicVineService.php
@@ -118,6 +118,8 @@ class ComicVineService
         $allIssues = [];
         $offset = 0;
         $limit = 100;
+        $maxPages = 10; // Safety cap to avoid exceeding execution time limits
+        $page = 0;
 
         try {
             do {
@@ -149,12 +151,13 @@ class ComicVineService
                 }
 
                 $offset += $limit;
+                $page++;
 
                 // Respect rate limits if we need more pages
                 if ($offset < $totalResults && ! empty($results)) {
                     usleep(400000);
                 }
-            } while ($offset < $totalResults && ! empty($results));
+            } while ($offset < $totalResults && ! empty($results) && $page < $maxPages);
         } catch (\Exception) {
             // Return whatever we collected so far
         }


### PR DESCRIPTION
## Summary
- Caps ComicVine volume issue fetching at 10 pages (1000 issues) to prevent request timeouts on very large series

## Test plan
- [ ] Import a large comic series (100+ issues) and verify it completes without timeout
- [ ] Verify the 1000 issue cap doesn't truncate normal-sized series

@coderabbitai full review