### PR TITLE
style: apply curated Rector ruleset (advisory CI → green)

### DIFF
--- a/app/Console/Commands/EnrichMovies.php
+++ b/app/Console/Commands/EnrichMovies.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Enums\WatchingStatus;
 use App\Models\Movie;
 use App\Services\TmdbService;
 use App\Services\TraktService;
 use Illuminate\Console\Command;
+use Illuminate\Support\Sleep;
 
 class EnrichMovies extends Command
 {
@@ -20,8 +22,8 @@ class EnrichMovies extends Command
         $limit = (int) $this->option('limit');
 
         $movies = Movie::whereNotNull('imdb_id')
-            ->where('status', \App\Enums\WatchingStatus::Watchlist->value)
-            ->where(function ($q) {
+            ->where('status', WatchingStatus::Watchlist->value)
+            ->where(function ($q): void {
                 $q->whereNull('poster_url')
                     ->orWhereNull('description');
             })
@@ -82,7 +84,7 @@ class EnrichMovies extends Command
             }
 
             // Simple rate limit protection (4 requests per second)
-            usleep(250000);
+            Sleep::usleep(250000);
         }
 
         $this->info('Enrichment complete.');

--- a/app/Console/Commands/FixBookStatuses.php
+++ b/app/Console/Commands/FixBookStatuses.php
@@ -28,8 +28,8 @@ class FixBookStatuses extends Command
         $total = Book::whereNotNull('shelves')->count();
         $this->info("Processing {$total} books with shelf data...");
 
-        Book::whereNotNull('shelves')->with('user')->each(function (Book $book) use ($extractShelves, &$statusUpdated, &$shelvesCreated, &$booksWithShelves) {
-            $shelfParts = array_map('trim', explode(',', $book->shelves ?? ''));
+        Book::whereNotNull('shelves')->with('user')->each(function (Book $book) use ($extractShelves, &$statusUpdated, &$shelvesCreated, &$booksWithShelves): void {
+            $shelfParts = array_map(trim(...), explode(',', $book->shelves ?? ''));
 
             // First part is always status
             $statusPart = strtolower($shelfParts[0]);
@@ -53,13 +53,16 @@ class FixBookStatuses extends Command
             // Extract custom shelves (everything after the first part that isn't a status keyword)
             if ($extractShelves && count($shelfParts) > 1) {
                 $customShelves = [];
+                $counter = count($shelfParts);
 
-                for ($i = 1; $i < count($shelfParts); $i++) {
+                for ($i = 1; $i < $counter; $i++) {
                     $shelfName = trim($shelfParts[$i]);
                     $shelfLower = strtolower($shelfName);
-
                     // Skip if it's a status keyword
-                    if (empty($shelfName) || in_array($shelfLower, $this->statusKeywords)) {
+                    if (empty($shelfName)) {
+                        continue;
+                    }
+                    if (in_array($shelfLower, $this->statusKeywords)) {
                         continue;
                     }
 
@@ -68,7 +71,7 @@ class FixBookStatuses extends Command
                     $shelvesCreated++;
                 }
 
-                if (! empty($customShelves)) {
+                if ($customShelves !== []) {
                     $book->bookShelves()->syncWithoutDetaching($customShelves);
                     $booksWithShelves++;
                 }

--- a/app/Console/Commands/ImportGoodreads.php
+++ b/app/Console/Commands/ImportGoodreads.php
@@ -6,6 +6,7 @@ namespace App\Console\Commands;
 
 use App\Models\User;
 use App\Services\JsonImportService;
+use Exception;
 use Illuminate\Console\Command;
 
 class ImportGoodreads extends Command
@@ -76,7 +77,7 @@ class ImportGoodreads extends Command
             $this->info("✓ No changes needed: {$skipped} books");
 
             return 0;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->error('Import failed: '.$e->getMessage());
 
             return 1;

--- a/app/Console/Commands/ImportImdbWatchlist.php
+++ b/app/Console/Commands/ImportImdbWatchlist.php
@@ -47,7 +47,7 @@ class ImportImdbWatchlist extends Command
 
             return 1;
         }
-        $headers = array_map(fn ($h) => (string) $h, $headerRow);
+        $headers = array_map(fn ($h): string => (string) $h, $headerRow);
 
         $importedCount = 0;
         $skippedCount = 0;
@@ -57,7 +57,7 @@ class ImportImdbWatchlist extends Command
                 continue;
             }
 
-            $data = array_combine($headers, array_map(fn ($v) => $v === null ? null : (string) $v, $row));
+            $data = array_combine($headers, array_map(fn ($v): ?string => $v ?? null, $row));
 
             $title = $this->strOf($data['Title'] ?? null);
             $imdbId = $this->strOf($data['Const'] ?? null);
@@ -75,10 +75,10 @@ class ImportImdbWatchlist extends Command
                 'title' => $title,
                 'imdb_id' => $imdbId,
                 'title_type' => $titleType,
-                'year' => ! empty($data['Year']) ? (int) $data['Year'] : null,
-                'runtime_minutes' => ! empty($data['Runtime (mins)']) ? (int) $data['Runtime (mins)'] : null,
-                'genres' => ! empty($data['Genres']) ? $data['Genres'] : null,
-                'imdb_rating' => ! empty($data['IMDb Rating']) ? $data['IMDb Rating'] : null,
+                'year' => empty($data['Year']) ? null : (int) $data['Year'],
+                'runtime_minutes' => empty($data['Runtime (mins)']) ? null : (int) $data['Runtime (mins)'],
+                'genres' => empty($data['Genres']) ? null : $data['Genres'],
+                'imdb_rating' => empty($data['IMDb Rating']) ? null : $data['IMDb Rating'],
                 'status' => WatchingStatus::Watchlist->value,
                 'date_added' => now(),
             ];

--- a/app/Jobs/FetchBookCover.php
+++ b/app/Jobs/FetchBookCover.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Models\Book;
+use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Drivers\Gd\Driver;
+use Intervention\Image\ImageManager;
 
 class FetchBookCover implements ShouldQueue
 {
@@ -45,7 +48,7 @@ class FetchBookCover implements ShouldQueue
         }
 
         // Skip if we already have a local cover
-        if ($book->cover_url && str_starts_with($book->cover_url, '/storage/')) {
+        if ($book->cover_url && str_starts_with((string) $book->cover_url, '/storage/')) {
             return;
         }
 
@@ -94,7 +97,7 @@ class FetchBookCover implements ShouldQueue
             }
 
             return null;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             Log::debug("FetchBookCover: Error processing external URL for book {$bookId}: {$e->getMessage()}");
 
             return null;
@@ -145,7 +148,7 @@ class FetchBookCover implements ShouldQueue
             }
 
             return $body;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             Log::debug("FetchBookCover: Error fetching {$url}: {$e->getMessage()}");
 
             return null;
@@ -167,7 +170,7 @@ class FetchBookCover implements ShouldQueue
 
             // Return the public URL path
             return '/storage/'.$filename;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             Log::error("FetchBookCover: Error storing image for book {$bookId}: {$e->getMessage()}");
 
             return null;
@@ -178,11 +181,11 @@ class FetchBookCover implements ShouldQueue
     {
         try {
             // Try to use Intervention Image v3 if available
-            if (class_exists(\Intervention\Image\ImageManager::class) &&
-                class_exists(\Intervention\Image\Drivers\Gd\Driver::class)) {
+            if (class_exists(ImageManager::class) &&
+                class_exists(Driver::class)) {
                 return $this->optimizeWithIntervention($imageData, $extension);
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             Log::debug("FetchBookCover: Intervention Image optimization failed: {$e->getMessage()}");
         }
 
@@ -193,8 +196,8 @@ class FetchBookCover implements ShouldQueue
     private function optimizeWithIntervention(string $imageData, string $extension): string
     {
         // Intervention Image v3 API
-        $manager = new \Intervention\Image\ImageManager(
-            new \Intervention\Image\Drivers\Gd\Driver
+        $manager = new ImageManager(
+            new Driver
         );
         $image = $manager->read($imageData);
 
@@ -202,16 +205,18 @@ class FetchBookCover implements ShouldQueue
         if ($image->width() > self::MAX_DIMENSION || $image->height() > self::MAX_DIMENSION) {
             $image->scaleDown(self::MAX_DIMENSION, self::MAX_DIMENSION);
         }
-
         // Encode with compression
         if ($extension === 'webp') {
             return (string) $image->toWebp(self::COMPRESSION_QUALITY);
-        } elseif ($extension === 'png') {
-            return (string) $image->toPng();
-        } else {
-            // JPEG or fallback
-            return (string) $image->toJpeg(self::COMPRESSION_QUALITY);
         }
+
+        // Encode with compression
+        if ($extension === 'png') {
+            return (string) $image->toPng();
+        }
+
+        // JPEG or fallback
+        return (string) $image->toJpeg(self::COMPRESSION_QUALITY);
     }
 
     private function detectImageExtension(string $data): string
@@ -234,7 +239,7 @@ class FetchBookCover implements ShouldQueue
         }
 
         // WebP
-        if (substr($magicBytes, 0, 4) === 'RIFF' && substr($data, 8, 4) === 'WEBP') {
+        if (str_starts_with($magicBytes, 'RIFF') && substr($data, 8, 4) === 'WEBP') {
             return 'webp';
         }
 

--- a/app/Jobs/FetchBookMetadata.php
+++ b/app/Jobs/FetchBookMetadata.php
@@ -6,10 +6,12 @@ namespace App\Jobs;
 
 use App\Models\Book;
 use App\Services\OpenLibraryService;
+use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Sleep;
 
 class FetchBookMetadata implements ShouldQueue
 {
@@ -113,9 +115,9 @@ class FetchBookMetadata implements ShouldQueue
                 ], now()->addHours(2));
 
                 // Small delay to avoid hammering the API
-                usleep(250000); // 250ms
+                Sleep::usleep(250000); // 250ms
 
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 Log::warning("FetchBookMetadata: Error fetching book {$bookId}: ".$e->getMessage());
             }
         }

--- a/app/Jobs/FetchMovieMetadata.php
+++ b/app/Jobs/FetchMovieMetadata.php
@@ -7,10 +7,12 @@ namespace App\Jobs;
 use App\Models\Movie;
 use App\Services\TmdbService;
 use App\Services\TraktService;
+use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Sleep;
 
 class FetchMovieMetadata implements ShouldQueue
 {
@@ -106,8 +108,8 @@ class FetchMovieMetadata implements ShouldQueue
                     } else {
                         // Fallback: search TV shows by show_name or title prefix
                         $showName = $movie->show_name;
-                        if (empty($showName) && str_contains($movie->title, ':')) {
-                            $showName = trim(explode(':', $movie->title, 2)[0]);
+                        if (empty($showName) && str_contains((string) $movie->title, ':')) {
+                            $showName = trim(explode(':', (string) $movie->title, 2)[0]);
                         }
 
                         if (! empty($showName)) {
@@ -132,8 +134,8 @@ class FetchMovieMetadata implements ShouldQueue
                     $showNameRaw = $updateData['show_name'] ?? $movie->show_name;
                     $showNameToPropagate = is_string($showNameRaw) ? $showNameRaw : null;
                     if ($posterToPropagate !== null || $showNameToPropagate !== null) {
-                        $titlePrefix = str_contains($movie->title, ':')
-                            ? trim(explode(':', $movie->title, 2)[0])
+                        $titlePrefix = str_contains((string) $movie->title, ':')
+                            ? trim(explode(':', (string) $movie->title, 2)[0])
                             : null;
                         Movie::propagateShowPoster(
                             $this->userId,
@@ -209,8 +211,8 @@ class FetchMovieMetadata implements ShouldQueue
                         $showPosterRaw = $updateData['poster_url'] ?? $movie->poster_url;
                         $showPoster = is_string($showPosterRaw) ? $showPosterRaw : null;
                         if ($showPoster !== null && in_array($movie->title_type, ['TV Series', 'TV Mini Series'], true)) {
-                            $titlePrefix = str_contains($movie->title, ':')
-                                ? trim(explode(':', $movie->title, 2)[0])
+                            $titlePrefix = str_contains((string) $movie->title, ':')
+                                ? trim(explode(':', (string) $movie->title, 2)[0])
                                 : $movie->title;
                             Movie::propagateShowPoster(
                                 $this->userId,
@@ -234,9 +236,9 @@ class FetchMovieMetadata implements ShouldQueue
                 ], now()->addHours(2));
 
                 // 300ms delay to respect TMDB rate limits
-                usleep(300000);
+                Sleep::usleep(300000);
 
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 Log::warning("FetchMovieMetadata: Error fetching movie {$movieId}: ".$e->getMessage());
             }
         }

--- a/app/Jobs/ImportFromJson.php
+++ b/app/Jobs/ImportFromJson.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
+use App\Models\Book;
 use App\Models\User;
 use App\Services\JsonImportService;
+use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
@@ -64,7 +66,7 @@ class ImportFromJson implements ShouldQueue
                     'errors' => $result['errors'],
                 ]);
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             Log::error("ImportFromJson: Error importing books for user {$user->id}", [
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
@@ -79,7 +81,7 @@ class ImportFromJson implements ShouldQueue
      */
     protected function dispatchCoverFetchJobs(array $bookIds): void
     {
-        $books = \App\Models\Book::whereIn('id', $bookIds)
+        $books = Book::whereIn('id', $bookIds)
             ->select('id', 'isbn', 'isbn13', 'cover_url')
             ->get();
 
@@ -87,7 +89,7 @@ class ImportFromJson implements ShouldQueue
             // Only dispatch for books with ISBN or direct cover URL
             if (($book->isbn || $book->isbn13) || $book->cover_url) {
                 // Add random delay to each job to spread network requests
-                FetchBookCover::dispatch($book->id)
+                dispatch(new FetchBookCover($book->id))
                     ->delay(random_int(10, 120)); // 10-120 seconds random delay
             }
         }

--- a/app/Livewire/Albums/AlbumDiscogsSearch.php
+++ b/app/Livewire/Albums/AlbumDiscogsSearch.php
@@ -8,6 +8,7 @@ use App\Enums\CollectionStatus;
 use App\Enums\OwnershipStatus;
 use App\Models\Album;
 use App\Services\DiscogsService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -86,7 +87,7 @@ class AlbumDiscogsSearch extends Component
 
         if ($discogsId || $discogsMasterId) {
             $existing = Album::where('user_id', Auth::id())
-                ->where(function ($q) use ($discogsId, $discogsMasterId) {
+                ->where(function ($q) use ($discogsId, $discogsMasterId): void {
                     if ($discogsId) {
                         $q->where('discogs_id', $discogsId);
                     }
@@ -138,7 +139,7 @@ class AlbumDiscogsSearch extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.albums.album-discogs-search', [
             'statuses' => CollectionStatus::cases(),

--- a/app/Livewire/Albums/AlbumForm.php
+++ b/app/Livewire/Albums/AlbumForm.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Albums;
 use App\Enums\CollectionStatus;
 use App\Enums\OwnershipStatus;
 use App\Models\Album;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -104,10 +105,10 @@ class AlbumForm extends Component
         $validated = is_array($validated) ? $validated : [];
 
         $genreValue = is_string($validated['genre'] ?? null) ? $validated['genre'] : '';
-        $genreArray = $genreValue !== '' ? array_map('trim', explode(',', $genreValue)) : [];
+        $genreArray = $genreValue !== '' ? array_map(trim(...), explode(',', $genreValue)) : [];
 
         $stylesValue = is_string($validated['styles'] ?? null) ? $validated['styles'] : '';
-        $stylesArray = $stylesValue !== '' ? array_map('trim', explode(',', $stylesValue)) : [];
+        $stylesArray = $stylesValue !== '' ? array_map(trim(...), explode(',', $stylesValue)) : [];
 
         $data = [
             'title' => $validated['title'],
@@ -143,11 +144,11 @@ class AlbumForm extends Component
 
     public function isEditing(): bool
     {
-        return $this->album !== null && $this->album->exists;
+        return $this->album instanceof Album && $this->album->exists;
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.albums.album-form', [
             'statuses' => CollectionStatus::cases(),

--- a/app/Livewire/Albums/AlbumIndex.php
+++ b/app/Livewire/Albums/AlbumIndex.php
@@ -8,6 +8,7 @@ use App\Enums\CollectionStatus;
 use App\Livewire\Concerns\WithAccentInsensitiveSearch;
 use App\Livewire\Concerns\WithIndexFiltering;
 use App\Models\Album;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
@@ -71,7 +72,7 @@ class AlbumIndex extends Component
     {
         if ($value) {
             $query = $this->buildQuery();
-            $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+            $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
         } else {
             $this->selected = [];
         }
@@ -109,7 +110,7 @@ class AlbumIndex extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $perPage = $this->viewMode === 'list' ? 25 : 18;
         $sortBy = $this->safeSortBy();

--- a/app/Livewire/Albums/AlbumShow.php
+++ b/app/Livewire/Albums/AlbumShow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Albums;
 
 use App\Models\Album;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -40,7 +41,7 @@ class AlbumShow extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.albums.album-show');
     }

--- a/app/Livewire/Anime/AnimeForm.php
+++ b/app/Livewire/Anime/AnimeForm.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Anime;
 
 use App\Enums\WatchingStatus;
 use App\Models\Anime;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -181,11 +182,11 @@ class AnimeForm extends Component
 
     public function isEditing(): bool
     {
-        return $this->anime !== null && $this->anime->exists;
+        return $this->anime instanceof Anime && $this->anime->exists;
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.anime.anime-form', [
             'statuses' => $this->getStatuses(),

--- a/app/Livewire/Anime/AnimeImport.php
+++ b/app/Livewire/Anime/AnimeImport.php
@@ -6,12 +6,15 @@ namespace App\Livewire\Anime;
 
 use App\Models\User;
 use App\Services\MalImportService;
+use Exception;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads;
+use RuntimeException;
 
 class AnimeImport extends Component
 {
@@ -57,7 +60,7 @@ class AnimeImport extends Component
 
             $this->totalEntries = $entries->count();
             $this->preview = $entries->take(5);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->addError('malUsername', $e->getMessage());
             $this->preview = null;
         } finally {
@@ -87,7 +90,7 @@ class AnimeImport extends Component
 
             $this->totalEntries = $entries->count();
             $this->preview = $entries->take(5);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->addError('file', $e->getMessage());
             $this->file = null;
             $this->preview = null;
@@ -107,7 +110,7 @@ class AnimeImport extends Component
                 $content = $this->uploadedContent();
 
                 if ($content === null) {
-                    throw new \RuntimeException('Could not read the uploaded file.');
+                    throw new RuntimeException('Could not read the uploaded file.');
                 }
 
                 $entries = $service->parseXml($content);
@@ -118,7 +121,7 @@ class AnimeImport extends Component
                 $entries,
                 $this->skipDuplicates
             );
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->importResult = [
                 'imported' => 0,
                 'skipped' => 0,
@@ -165,7 +168,7 @@ class AnimeImport extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.anime.anime-import');
     }

--- a/app/Livewire/Anime/AnimeIndex.php
+++ b/app/Livewire/Anime/AnimeIndex.php
@@ -8,6 +8,7 @@ use App\Enums\WatchingStatus;
 use App\Livewire\Concerns\WithAccentInsensitiveSearch;
 use App\Livewire\Concerns\WithIndexFiltering;
 use App\Models\Anime;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Layout;
@@ -92,21 +93,21 @@ class AnimeIndex extends Component
         if ($value) {
             $query = Anime::query()
                 ->where('user_id', Auth::id())
-                ->when($this->status, function ($query) {
+                ->when($this->status, function ($query): void {
                     $query->where('status', $this->status);
                 })
-                ->when($this->genre, function ($query) {
+                ->when($this->genre, function ($query): void {
                     $query->where('genres', 'like', '%'.$this->genre.'%');
                 })
-                ->when($this->mediaType, function ($query) {
+                ->when($this->mediaType, function ($query): void {
                     $query->where('media_type', $this->mediaType);
                 });
 
             if ($this->search) {
                 $this->applyAccentInsensitiveSearch($query, $this->search, ['title', 'original_title', 'studios']);
-                $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+                $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
             } else {
-                $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+                $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
             }
         } else {
             $this->selected = [];
@@ -136,7 +137,7 @@ class AnimeIndex extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $perPage = $this->viewMode === 'list' ? 25 : 18;
         $sortBy = $this->safeSortBy();
@@ -144,13 +145,13 @@ class AnimeIndex extends Component
 
         $query = Anime::query()
             ->where('user_id', Auth::id())
-            ->when($this->status, function ($query) {
+            ->when($this->status, function ($query): void {
                 $query->where('status', $this->status);
             })
-            ->when($this->genre, function ($query) {
+            ->when($this->genre, function ($query): void {
                 $query->where('genres', 'like', '%'.$this->genre.'%');
             })
-            ->when($this->mediaType, function ($query) {
+            ->when($this->mediaType, function ($query): void {
                 $query->where('media_type', $this->mediaType);
             });
 

--- a/app/Livewire/Anime/AnimeMetadataEnrichment.php
+++ b/app/Livewire/Anime/AnimeMetadataEnrichment.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Livewire\Anime;
 
+use App\Livewire\Concerns\WithMetadataEnrichment;
+use App\Livewire\Concerns\WithSourcePriority;
 use App\Models\Anime;
 use App\Services\JikanService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Layout;
@@ -13,8 +16,8 @@ use Livewire\Component;
 
 class AnimeMetadataEnrichment extends Component
 {
-    use \App\Livewire\Concerns\WithMetadataEnrichment;
-    use \App\Livewire\Concerns\WithSourcePriority;
+    use WithMetadataEnrichment;
+    use WithSourcePriority;
 
     /** @var list<string> */
     public array $sourcePriority = ['current', 'jikan'];
@@ -119,7 +122,7 @@ class AnimeMetadataEnrichment extends Component
             ->where('user_id', Auth::id())
             ->orderByRaw("metadata_fetched_at IS NULL DESC, {$randomFunction}")
             ->get(['id', 'title', 'original_title', 'mal_id', 'year', 'description', 'poster_url', 'runtime_minutes', 'genres', 'studios', 'episodes_total', 'media_type', 'metadata_fetched_at'])
-            ->map(function ($anime) {
+            ->map(function (Anime $anime): array {
                 $missing = $this->getMissingFields($anime);
 
                 return [
@@ -139,7 +142,7 @@ class AnimeMetadataEnrichment extends Component
                         'original_title' => $anime->original_title,
                     ],
                     'missing' => $missing,
-                    'has_missing' => ! empty($missing),
+                    'has_missing' => $missing !== [],
                 ];
             })
             ->all();
@@ -179,7 +182,7 @@ class AnimeMetadataEnrichment extends Component
         $service = app(JikanService::class);
 
         $toFetch = collect($this->animeNeedingEnrichment)
-            ->filter(fn ($a) => (bool) $a['has_missing'])
+            ->filter(fn ($a): bool => (bool) $a['has_missing'])
             ->take($this->batchLimit);
 
         $applied = 0;
@@ -266,7 +269,7 @@ class AnimeMetadataEnrichment extends Component
 
     public function applyMetadata(): void
     {
-        if (! $this->reviewingAnimeId || ! $this->reviewingMetadata || empty($this->selectedFields)) {
+        if (! $this->reviewingAnimeId || ! $this->reviewingMetadata || $this->selectedFields === []) {
             $this->closeReviewModal();
 
             return;
@@ -284,7 +287,7 @@ class AnimeMetadataEnrichment extends Component
 
         $updateData = $this->buildUpdateData();
 
-        if (! empty($updateData)) {
+        if ($updateData !== []) {
             $anime->update($updateData);
         }
 
@@ -309,7 +312,7 @@ class AnimeMetadataEnrichment extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.anime.anime-metadata-enrichment');
     }

--- a/app/Livewire/Anime/AnimeSettings.php
+++ b/app/Livewire/Anime/AnimeSettings.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Anime;
 
 use App\Models\Anime;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -73,7 +74,7 @@ class AnimeSettings extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.anime.anime-settings');
     }

--- a/app/Livewire/Anime/AnimeShow.php
+++ b/app/Livewire/Anime/AnimeShow.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Anime;
 use App\Enums\WatchingStatus;
 use App\Models\Anime;
 use App\Services\JikanService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -148,7 +149,7 @@ class AnimeShow extends Component
             $updates['mal_id'] = $this->fetchedMetadata['mal_id'];
         }
 
-        if (! empty($updates)) {
+        if ($updates !== []) {
             $updates['metadata_fetched_at'] = now();
             $this->anime->update($updates);
         } else {
@@ -178,7 +179,7 @@ class AnimeShow extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.anime.anime-show', [
             'statuses' => $this->getStatuses(),

--- a/app/Livewire/BoardGames/BoardGameBggSearch.php
+++ b/app/Livewire/BoardGames/BoardGameBggSearch.php
@@ -7,6 +7,7 @@ namespace App\Livewire\BoardGames;
 use App\Enums\BoardGameStatus;
 use App\Models\BoardGame;
 use App\Services\BggService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -115,7 +116,7 @@ class BoardGameBggSearch extends Component
         $boardGame = BoardGame::create([
             'user_id' => Auth::id(),
             'title' => $this->title,
-            'genre' => ! empty($this->genre) ? $this->genre : null,
+            'genre' => $this->genre === [] ? null : $this->genre,
             'description' => $this->description ?: null,
             'cover_url' => $this->cover_url ?: null,
             'year_published' => $this->year_published,
@@ -167,7 +168,7 @@ class BoardGameBggSearch extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.board-games.board-game-bgg-search', [
             'statuses' => BoardGameStatus::cases(),

--- a/app/Livewire/BoardGames/BoardGameForm.php
+++ b/app/Livewire/BoardGames/BoardGameForm.php
@@ -6,6 +6,7 @@ namespace App\Livewire\BoardGames;
 
 use App\Enums\BoardGameStatus;
 use App\Models\BoardGame;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -127,7 +128,7 @@ class BoardGameForm extends Component
 
         $data = [
             'title' => $validated['title'],
-            'genre' => ! empty($validated['genre']) ? $validated['genre'] : null,
+            'genre' => empty($validated['genre']) ? null : $validated['genre'],
             'description' => $validated['description'] ?: null,
             'cover_url' => $validated['cover_url'] ?: null,
             'year_published' => $validated['year_published'],
@@ -160,11 +161,11 @@ class BoardGameForm extends Component
 
     public function isEditing(): bool
     {
-        return $this->boardGame !== null && $this->boardGame->exists;
+        return $this->boardGame instanceof BoardGame && $this->boardGame->exists;
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.board-games.board-game-form', [
             'statuses' => BoardGameStatus::cases(),

--- a/app/Livewire/BoardGames/BoardGameIndex.php
+++ b/app/Livewire/BoardGames/BoardGameIndex.php
@@ -8,6 +8,7 @@ use App\Enums\BoardGameStatus;
 use App\Livewire\Concerns\WithAccentInsensitiveSearch;
 use App\Livewire\Concerns\WithIndexFiltering;
 use App\Models\BoardGame;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
@@ -80,7 +81,7 @@ class BoardGameIndex extends Component
     {
         if ($value) {
             $query = $this->buildQuery();
-            $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+            $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
         } else {
             $this->selected = [];
         }
@@ -122,7 +123,7 @@ class BoardGameIndex extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $perPage = $this->viewMode === 'list' ? 25 : 18;
         $sortBy = $this->safeSortBy();

--- a/app/Livewire/BoardGames/BoardGameShow.php
+++ b/app/Livewire/BoardGames/BoardGameShow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\BoardGames;
 
 use App\Models\BoardGame;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -40,7 +41,7 @@ class BoardGameShow extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.board-games.board-game-show');
     }

--- a/app/Livewire/Books/BookForm.php
+++ b/app/Livewire/Books/BookForm.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Books;
 
 use App\Enums\ReadingStatus;
 use App\Models\Book;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -139,12 +140,10 @@ class BookForm extends Component
         $validated['date_finished'] = $this->parseDateInput($validated['date_finished'] ?? null);
 
         // Validate date_finished >= date_started if both are present
-        if ($validated['date_started'] && $validated['date_finished']) {
-            if ($validated['date_finished'] < $validated['date_started']) {
-                $this->addError('date_finished', 'Date read must be after or equal to date started.');
+        if ($validated['date_started'] && $validated['date_finished'] && $validated['date_finished'] < $validated['date_started']) {
+            $this->addError('date_finished', 'Date read must be after or equal to date started.');
 
-                return;
-            }
+            return;
         }
 
         $data = [
@@ -217,11 +216,11 @@ class BookForm extends Component
 
     public function isEditing(): bool
     {
-        return $this->book !== null && $this->book->exists;
+        return $this->book instanceof Book && $this->book->exists;
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.books.book-form', [
             'statuses' => $this->getStatuses(),

--- a/app/Livewire/Books/BookImport.php
+++ b/app/Livewire/Books/BookImport.php
@@ -9,12 +9,16 @@ use App\Models\Book;
 use App\Models\User;
 use App\Services\GoodReadsImportService;
 use App\Services\JsonImportService;
+use Exception;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use InvalidArgumentException;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads;
+use RuntimeException;
 
 class BookImport extends Component
 {
@@ -77,7 +81,7 @@ class BookImport extends Component
             }
 
             $this->preview = $books->take(10);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             $this->addError('file', $e->getMessage());
             $this->file = null;
             $this->preview = null;
@@ -93,7 +97,7 @@ class BookImport extends Component
             $content = $this->uploadedContent();
 
             if ($content === null) {
-                throw new \RuntimeException('Could not read the uploaded file.');
+                throw new RuntimeException('Could not read the uploaded file.');
             }
 
             $user = $this->currentUser();
@@ -108,7 +112,7 @@ class BookImport extends Component
 
             // Dispatch cover fetch jobs for imported books (runs after response)
             $this->coverJobsDispatched = $this->dispatchCoverFetchJobs($this->importResult['book_ids']);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->importResult = [
                 'imported' => 0,
                 'skipped' => 0,
@@ -177,7 +181,7 @@ class BookImport extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.books.book-import');
     }

--- a/app/Livewire/Books/BookIndex.php
+++ b/app/Livewire/Books/BookIndex.php
@@ -8,6 +8,7 @@ use App\Enums\ReadingStatus;
 use App\Livewire\Concerns\WithAccentInsensitiveSearch;
 use App\Livewire\Concerns\WithIndexFiltering;
 use App\Models\Book;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Layout;
@@ -113,12 +114,12 @@ class BookIndex extends Component
         if ($value) {
             $query = Book::query()
                 ->where('user_id', Auth::id())
-                ->when($this->status, function ($query) {
+                ->when($this->status, function ($query): void {
                     $query->where('status', $this->status);
                 })
-                ->when($this->tag, function ($query) {
+                ->when($this->tag, function ($query): void {
                     if ($this->tag === '__untagged__') {
-                        $query->where(function ($q) {
+                        $query->where(function ($q): void {
                             $q->whereNull('shelves')
                                 ->orWhere('shelves', '')
                                 ->orWhereRaw("TRIM(shelves) IN ('read', 'to-read', 'currently-reading', 'want-to-read')");
@@ -130,9 +131,9 @@ class BookIndex extends Component
 
             if ($this->search) {
                 $this->applyAccentInsensitiveSearch($query, $this->search, ['title', 'author']);
-                $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+                $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
             } else {
-                $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+                $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
             }
         } else {
             $this->selected = [];
@@ -162,7 +163,7 @@ class BookIndex extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $perPage = $this->viewMode === 'list' ? 25 : 18;
         $sortBy = $this->safeSortBy();
@@ -171,13 +172,13 @@ class BookIndex extends Component
         $query = Book::query()
             ->where('user_id', Auth::id())
             ->with('bookShelves')
-            ->when($this->status, function ($query) {
+            ->when($this->status, function ($query): void {
                 $query->where('status', $this->status);
             })
-            ->when($this->tag, function ($query) {
+            ->when($this->tag, function ($query): void {
                 if ($this->tag === '__untagged__') {
                     // Filter for books with no tags
-                    $query->where(function ($q) {
+                    $query->where(function ($q): void {
                         $q->whereNull('shelves')
                             ->orWhere('shelves', '')
                             ->orWhereRaw("TRIM(shelves) IN ('read', 'to-read', 'currently-reading', 'want-to-read')");

--- a/app/Livewire/Books/BookOpenLibrarySearch.php
+++ b/app/Livewire/Books/BookOpenLibrarySearch.php
@@ -8,6 +8,7 @@ use App\Enums\ReadingStatus;
 use App\Models\Book;
 use App\Services\GoogleBooksService;
 use App\Services\OpenLibraryService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -127,8 +128,8 @@ class BookOpenLibrarySearch extends Component
             $details = $service->fetchByIsbn($this->isbn);
             if ($details) {
                 $this->description = $this->strOf($details['description'] ?? null);
-                $this->page_count = $this->page_count ?? $this->intOrNull($details['page_count'] ?? null);
-                $this->publisher = $this->publisher ?? $this->strOrNull($details['publisher'] ?? null);
+                $this->page_count ??= $this->intOrNull($details['page_count'] ?? null);
+                $this->publisher ??= $this->strOrNull($details['publisher'] ?? null);
             }
         }
 
@@ -199,7 +200,7 @@ class BookOpenLibrarySearch extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.books.book-openlibrary-search', [
             'statuses' => ReadingStatus::cases(),

--- a/app/Livewire/Books/BookSettings.php
+++ b/app/Livewire/Books/BookSettings.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Books;
 
 use App\Jobs\FetchBookCover;
 use App\Models\Book;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Attributes\Layout;
@@ -79,7 +80,7 @@ class BookSettings extends Component
     {
         $query = Book::query()
             ->where('user_id', Auth::id())
-            ->where(function ($q) {
+            ->where(function ($q): void {
                 $q->whereNotNull('isbn')
                     ->orWhereNotNull('isbn13');
             });
@@ -89,8 +90,8 @@ class BookSettings extends Component
 
         // Delete local cover files
         $filesToDelete = $books
-            ->filter(fn ($book) => $book->cover_url && str_starts_with($book->cover_url, '/storage/covers/'))
-            ->map(fn ($book) => str_replace('/storage/', '', $book->cover_url ?? ''))
+            ->filter(fn ($book): bool => $book->cover_url && str_starts_with((string) $book->cover_url, '/storage/covers/'))
+            ->map(fn ($book): string => str_replace('/storage/', '', $book->cover_url ?? ''))
             ->values()
             ->all();
 
@@ -103,7 +104,7 @@ class BookSettings extends Component
 
         // Batch dispatch cover fetch jobs
         foreach ($books as $book) {
-            FetchBookCover::dispatch($book->id);
+            dispatch(new FetchBookCover($book->id));
         }
 
         $count = $books->count();
@@ -112,7 +113,7 @@ class BookSettings extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.books.book-settings');
     }

--- a/app/Livewire/Books/BookShow.php
+++ b/app/Livewire/Books/BookShow.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Books;
 
 use App\Enums\ReadingStatus;
 use App\Models\Book;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
@@ -108,7 +109,7 @@ class BookShow extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.books.book-show', [
             'statuses' => $this->getStatuses(),

--- a/app/Livewire/Books/JsonImport.php
+++ b/app/Livewire/Books/JsonImport.php
@@ -7,12 +7,15 @@ namespace App\Livewire\Books;
 use App\Jobs\ImportFromJson;
 use App\Models\User;
 use App\Services\JsonImportService;
+use Exception;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads;
+use RuntimeException;
 
 class JsonImport extends Component
 {
@@ -69,7 +72,7 @@ class JsonImport extends Component
 
             $this->preview = $books->take(10);
             $this->importStatus = 'Found '.$books->count().' books in JSON file';
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->importStatus = 'Error parsing JSON: '.$e->getMessage();
             $this->preview = null;
         }
@@ -86,14 +89,10 @@ class JsonImport extends Component
             $content = $this->uploadedContent();
 
             if ($content === null) {
-                throw new \RuntimeException('Could not read the uploaded file.');
+                throw new RuntimeException('Could not read the uploaded file.');
             }
 
-            ImportFromJson::dispatch(
-                $this->currentUser()->id,
-                $content,
-                $this->skipDuplicates
-            );
+            dispatch(new ImportFromJson($this->currentUser()->id, $content, $this->skipDuplicates));
 
             $this->importStatus = 'Import job queued! Books will be imported in the background.';
             $this->importing = false;
@@ -101,7 +100,7 @@ class JsonImport extends Component
             $this->file = null;
 
             $this->dispatch('import-queued');
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->importStatus = 'Error: '.$e->getMessage();
             $this->importing = false;
         }
@@ -141,7 +140,7 @@ class JsonImport extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.books.json-import');
     }

--- a/app/Livewire/Books/MetadataEnrichment.php
+++ b/app/Livewire/Books/MetadataEnrichment.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace App\Livewire\Books;
 
 use App\Jobs\FetchBookMetadata;
+use App\Livewire\Concerns\WithMetadataEnrichment;
+use App\Livewire\Concerns\WithSourcePriority;
 use App\Models\Book;
 use App\Services\OpenLibraryService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Attributes\Layout;
@@ -14,8 +17,8 @@ use Livewire\Component;
 
 class MetadataEnrichment extends Component
 {
-    use \App\Livewire\Concerns\WithMetadataEnrichment;
-    use \App\Livewire\Concerns\WithSourcePriority;
+    use WithMetadataEnrichment;
+    use WithSourcePriority;
 
     // Source priority: sources listed in order of preference
     /** @var list<string> */
@@ -136,12 +139,12 @@ class MetadataEnrichment extends Component
         // Find all books with ISBN that have missing metadata
         $this->booksNeedingEnrichment = Book::query()
             ->where('user_id', Auth::id())
-            ->where(function ($query) {
+            ->where(function ($query): void {
                 $query->whereNotNull('isbn')
                     ->orWhereNotNull('isbn13');
             })
             ->get(['id', 'title', 'author', 'isbn', 'isbn13', 'description', 'publisher', 'page_count', 'published_date'])
-            ->map(function ($book) {
+            ->map(function (Book $book): array {
                 $missing = $this->getMissingFields($book);
 
                 return [
@@ -156,7 +159,7 @@ class MetadataEnrichment extends Component
                         'published_date' => $book->published_date?->format('Y-m-d'),
                     ],
                     'missing' => $missing,
-                    'has_missing' => ! empty($missing),
+                    'has_missing' => $missing !== [],
                 ];
             })
             ->all();
@@ -198,8 +201,8 @@ class MetadataEnrichment extends Component
 
         // Get books that need enrichment (have missing fields)
         $booksToFetch = collect($this->booksNeedingEnrichment)
-            ->filter(fn ($book) => (bool) $book['has_missing'])
-            ->filter(fn ($book) => ! empty($book['isbn']))
+            ->filter(fn ($book): bool => (bool) $book['has_missing'])
+            ->filter(fn ($book): bool => ! empty($book['isbn']))
             ->take($this->batchLimit)
             ->pluck('id')
             ->all();
@@ -272,7 +275,7 @@ class MetadataEnrichment extends Component
 
     public function applyMetadata(): void
     {
-        if (! $this->reviewingBookId || ! $this->reviewingMetadata || empty($this->selectedFields)) {
+        if (! $this->reviewingBookId || ! $this->reviewingMetadata || $this->selectedFields === []) {
             $this->closeReviewModal();
 
             return;
@@ -290,7 +293,7 @@ class MetadataEnrichment extends Component
 
         $updateData = $this->buildUpdateData();
 
-        if (! empty($updateData)) {
+        if ($updateData !== []) {
             $book->update($updateData);
         }
 
@@ -316,7 +319,7 @@ class MetadataEnrichment extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         // Auto-refresh job status if running
         if ($this->jobStatus && $this->jobStatus['status'] === 'running') {

--- a/app/Livewire/Books/ReadQueue.php
+++ b/app/Livewire/Books/ReadQueue.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Books;
 
 use App\Enums\ReadingStatus;
 use App\Models\Book;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -136,7 +137,7 @@ class ReadQueue extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $queuedBooks = Book::where('user_id', Auth::id())
             ->whereNotNull('queue_position')

--- a/app/Livewire/Comics/ComicForm.php
+++ b/app/Livewire/Comics/ComicForm.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Comics;
 
 use App\Enums\ReadingStatus;
 use App\Models\Comic;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -132,12 +133,10 @@ class ComicForm extends Component
         $validated['date_started'] = $this->parseDateInput($validated['date_started'] ?? null);
         $validated['date_finished'] = $this->parseDateInput($validated['date_finished'] ?? null);
 
-        if ($validated['date_started'] && $validated['date_finished']) {
-            if ($validated['date_finished'] < $validated['date_started']) {
-                $this->addError('date_finished', 'Date finished must be after or equal to date started.');
+        if ($validated['date_started'] && $validated['date_finished'] && $validated['date_finished'] < $validated['date_started']) {
+            $this->addError('date_finished', 'Date finished must be after or equal to date started.');
 
-                return;
-            }
+            return;
         }
 
         $data = [
@@ -176,11 +175,11 @@ class ComicForm extends Component
 
     public function isEditing(): bool
     {
-        return $this->comic !== null && $this->comic->exists;
+        return $this->comic instanceof Comic && $this->comic->exists;
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.comics.comic-form', [
             'statuses' => ReadingStatus::cases(),

--- a/app/Livewire/Comics/ComicImport.php
+++ b/app/Livewire/Comics/ComicImport.php
@@ -6,12 +6,16 @@ namespace App\Livewire\Comics;
 
 use App\Models\User;
 use App\Services\ComicImportService;
+use Exception;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use InvalidArgumentException;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads;
+use RuntimeException;
 
 class ComicImport extends Component
 {
@@ -67,14 +71,10 @@ class ComicImport extends Component
         try {
             $service = new ComicImportService;
 
-            if ($this->format === 'json') {
-                $comics = $service->parseJson($content);
-            } else {
-                $comics = $service->parseCSV($content);
-            }
+            $comics = $this->format === 'json' ? $service->parseJson($content) : $service->parseCSV($content);
 
             $this->preview = $comics->take(10);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             $this->addError('file', $e->getMessage());
             $this->file = null;
             $this->preview = null;
@@ -90,23 +90,19 @@ class ComicImport extends Component
             $content = $this->uploadedContent();
 
             if ($content === null) {
-                throw new \RuntimeException('Could not read the uploaded file.');
+                throw new RuntimeException('Could not read the uploaded file.');
             }
 
             $service = new ComicImportService;
 
-            if ($this->format === 'json') {
-                $comics = $service->parseJson($content);
-            } else {
-                $comics = $service->parseCSV($content);
-            }
+            $comics = $this->format === 'json' ? $service->parseJson($content) : $service->parseCSV($content);
 
             $this->importResult = $service->importComics(
                 $this->currentUser(),
                 $comics,
                 $this->skipDuplicates
             );
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->importResult = [
                 'imported' => 0,
                 'skipped' => 0,
@@ -152,7 +148,7 @@ class ComicImport extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.comics.comic-import');
     }

--- a/app/Livewire/Comics/ComicIndex.php
+++ b/app/Livewire/Comics/ComicIndex.php
@@ -8,6 +8,7 @@ use App\Enums\ReadingStatus;
 use App\Livewire\Concerns\WithAccentInsensitiveSearch;
 use App\Livewire\Concerns\WithIndexFiltering;
 use App\Models\Comic;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Layout;
@@ -95,18 +96,18 @@ class ComicIndex extends Component
         if ($value) {
             $query = Comic::query()
                 ->where('user_id', Auth::id())
-                ->when($this->status, function ($query) {
+                ->when($this->status, function ($query): void {
                     $query->where('status', $this->status);
                 })
-                ->when($this->publisher, function ($query) {
+                ->when($this->publisher, function ($query): void {
                     $query->where('publisher', $this->publisher);
                 });
 
             if ($this->search) {
                 $this->applyAccentInsensitiveSearch($query, $this->search, ['title', 'publisher']);
-                $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+                $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
             } else {
-                $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+                $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
             }
         } else {
             $this->selected = [];
@@ -128,7 +129,7 @@ class ComicIndex extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $perPage = $this->viewMode === 'list' ? 25 : 18;
         $sortBy = $this->safeSortBy();
@@ -136,10 +137,10 @@ class ComicIndex extends Component
 
         $query = Comic::query()
             ->where('user_id', Auth::id())
-            ->when($this->status, function ($query) {
+            ->when($this->status, function ($query): void {
                 $query->where('status', $this->status);
             })
-            ->when($this->publisher, function ($query) {
+            ->when($this->publisher, function ($query): void {
                 $query->where('publisher', $this->publisher);
             });
 

--- a/app/Livewire/Comics/ComicIssueShow.php
+++ b/app/Livewire/Comics/ComicIssueShow.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Comics;
 use App\Enums\ReadingStatus;
 use App\Models\Comic;
 use App\Models\ComicIssue;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -61,7 +62,7 @@ class ComicIssueShow extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.comics.comic-issue-show', [
             'statuses' => ReadingStatus::cases(),

--- a/app/Livewire/Comics/ComicSettings.php
+++ b/app/Livewire/Comics/ComicSettings.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Comics;
 
 use App\Models\Comic;
 use App\Services\ComicVineService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -74,7 +75,7 @@ class ComicSettings extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $comicVine = app(ComicVineService::class);
 

--- a/app/Livewire/Comics/ComicShow.php
+++ b/app/Livewire/Comics/ComicShow.php
@@ -8,6 +8,7 @@ use App\Enums\ReadingStatus;
 use App\Models\Comic;
 use App\Models\ComicIssue;
 use App\Services\ComicVineService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -78,7 +79,7 @@ class ComicShow extends Component
         $comicVine = app(ComicVineService::class);
         $this->availableIssues = $comicVine->fetchVolumeIssues($this->comic->comicvine_volume_id);
 
-        if (empty($this->availableIssues)) {
+        if ($this->availableIssues === []) {
             session()->flash('error', 'No issues found or could not fetch from Comic Vine.');
             $this->fetchingIssues = false;
 
@@ -91,11 +92,9 @@ class ComicShow extends Component
             ->all();
 
         // Filter out issues that already exist in our database
-        $this->availableIssues = array_filter($this->availableIssues, function ($issue) use ($existingIds) {
-            return ! in_array($issue['issue_id'], $existingIds);
-        });
+        $this->availableIssues = array_filter($this->availableIssues, fn (array $issue): bool => ! in_array($issue['issue_id'], $existingIds));
 
-        if (empty($this->availableIssues)) {
+        if ($this->availableIssues === []) {
             session()->flash('message', 'All issues from Comic Vine are already in your library.');
             $this->fetchingIssues = false;
 
@@ -111,18 +110,14 @@ class ComicShow extends Component
 
     public function updatedSelectAll(mixed $value): void
     {
-        if ($value) {
-            $this->selectedIssueIds = array_column($this->availableIssues, 'issue_id');
-        } else {
-            $this->selectedIssueIds = [];
-        }
+        $this->selectedIssueIds = $value ? array_column($this->availableIssues, 'issue_id') : [];
     }
 
     public function importSelectedIssues(): void
     {
         $this->authorize('update', $this->comic);
 
-        if (empty($this->selectedIssueIds)) {
+        if ($this->selectedIssueIds === []) {
             $this->showImportModal = false;
 
             return;
@@ -195,7 +190,7 @@ class ComicShow extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $issues = $this->comic->issues()
             ->orderByRaw("CAST(NULLIF(issue_number, '') AS NUMERIC) ASC")

--- a/app/Livewire/Comics/ComicVineSearch.php
+++ b/app/Livewire/Comics/ComicVineSearch.php
@@ -8,6 +8,7 @@ use App\Enums\ReadingStatus;
 use App\Models\Comic;
 use App\Models\ComicIssue;
 use App\Services\ComicVineService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -177,7 +178,7 @@ class ComicVineSearch extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.comics.comic-vine-search', [
             'statuses' => ReadingStatus::cases(),

--- a/app/Livewire/Concerns/WithAccentInsensitiveSearch.php
+++ b/app/Livewire/Concerns/WithAccentInsensitiveSearch.php
@@ -22,7 +22,7 @@ trait WithAccentInsensitiveSearch
         $words = preg_split('/\s+/', trim($search)) ?: [];
 
         foreach ($words as $word) {
-            $query->where(function (Builder $q) use ($word, $columns, $grammar) {
+            $query->where(function (Builder $q) use ($word, $columns, $grammar): void {
                 foreach ($columns as $column) {
                     $q->orWhereRaw('unaccent(COALESCE('.$grammar->wrap($column).", '')) ILIKE unaccent(?)", ['%'.$word.'%']);
                 }

--- a/app/Livewire/Concerts/ConcertForm.php
+++ b/app/Livewire/Concerts/ConcertForm.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Concerts;
 
 use App\Enums\ListeningStatus;
 use App\Models\Concert;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -142,11 +143,11 @@ class ConcertForm extends Component
 
     public function isEditing(): bool
     {
-        return $this->concert !== null && $this->concert->exists;
+        return $this->concert instanceof Concert && $this->concert->exists;
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.concerts.concert-form', [
             'statuses' => ListeningStatus::cases(),

--- a/app/Livewire/Concerts/ConcertIndex.php
+++ b/app/Livewire/Concerts/ConcertIndex.php
@@ -8,6 +8,7 @@ use App\Enums\ListeningStatus;
 use App\Livewire\Concerns\WithAccentInsensitiveSearch;
 use App\Livewire\Concerns\WithIndexFiltering;
 use App\Models\Concert;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
@@ -81,7 +82,7 @@ class ConcertIndex extends Component
     {
         if ($value) {
             $query = $this->buildQuery();
-            $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+            $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
         } else {
             $this->selected = [];
         }
@@ -119,7 +120,7 @@ class ConcertIndex extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $perPage = $this->viewMode === 'list' ? 25 : 18;
         $sortBy = $this->safeSortBy();

--- a/app/Livewire/Concerts/ConcertSetlistFmSearch.php
+++ b/app/Livewire/Concerts/ConcertSetlistFmSearch.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Concerts;
 use App\Enums\ListeningStatus;
 use App\Models\Concert;
 use App\Services\SetlistFmService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -116,7 +117,7 @@ class ConcertSetlistFmSearch extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.concerts.concert-setlistfm-search', [
             'statuses' => ListeningStatus::cases(),

--- a/app/Livewire/Concerts/ConcertShow.php
+++ b/app/Livewire/Concerts/ConcertShow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Concerts;
 
 use App\Models\Concert;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -40,7 +41,7 @@ class ConcertShow extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.concerts.concert-show');
     }

--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -10,8 +10,10 @@ use App\Enums\PlayingStatus;
 use App\Enums\ReadingStatus;
 use App\Enums\WatchingStatus;
 use App\Models\User;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 
@@ -65,7 +67,7 @@ class Dashboard extends Component
     {
         $user = $this->currentUser();
         $year = now()->year;
-        $driver = \Illuminate\Support\Facades\DB::connection()->getDriverName();
+        $driver = DB::connection()->getDriverName();
         $yearSql = $driver === 'pgsql' ? 'CAST(EXTRACT(YEAR FROM %s) AS INTEGER)' : "strftime('%%Y', %s)";
 
         $bookStats = $user->books()
@@ -95,7 +97,7 @@ class Dashboard extends Component
     {
         $user = $this->currentUser();
         $year = now()->year;
-        $driver = \Illuminate\Support\Facades\DB::connection()->getDriverName();
+        $driver = DB::connection()->getDriverName();
         $yearSql = $driver === 'pgsql' ? 'CAST(EXTRACT(YEAR FROM %s) AS INTEGER)' : "strftime('%%Y', %s)";
 
         $stats = $user->movies()
@@ -118,7 +120,7 @@ class Dashboard extends Component
     {
         $user = $this->currentUser();
         $year = now()->year;
-        $driver = \Illuminate\Support\Facades\DB::connection()->getDriverName();
+        $driver = DB::connection()->getDriverName();
         $yearSql = $driver === 'pgsql' ? 'CAST(EXTRACT(YEAR FROM %s) AS INTEGER)' : "strftime('%%Y', %s)";
 
         $stats = $user->anime()
@@ -182,7 +184,7 @@ class Dashboard extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.dashboard', [
             'categories' => $this->getCategories(),

--- a/app/Livewire/Games/GameForm.php
+++ b/app/Livewire/Games/GameForm.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Games;
 use App\Enums\OwnershipStatus;
 use App\Enums\PlayingStatus;
 use App\Models\Game;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -186,8 +187,8 @@ class GameForm extends Component
 
         $data = [
             'title' => $validated['title'],
-            'platform' => ! empty($validated['platform']) ? $validated['platform'] : null,
-            'genre' => ! empty($validated['genre']) ? $validated['genre'] : null,
+            'platform' => empty($validated['platform']) ? null : $validated['platform'],
+            'genre' => empty($validated['genre']) ? null : $validated['genre'],
             'description' => $validated['description'] ?: null,
             'cover_url' => $validated['cover_url'] ?: null,
             'release_date' => $validated['release_date'],
@@ -222,11 +223,11 @@ class GameForm extends Component
 
     public function isEditing(): bool
     {
-        return $this->game !== null && $this->game->exists;
+        return $this->game instanceof Game && $this->game->exists;
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.games.game-form', [
             'statuses' => PlayingStatus::cases(),

--- a/app/Livewire/Games/GameIgdbSearch.php
+++ b/app/Livewire/Games/GameIgdbSearch.php
@@ -8,6 +8,7 @@ use App\Enums\OwnershipStatus;
 use App\Enums\PlayingStatus;
 use App\Models\Game;
 use App\Services\IgdbService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -222,8 +223,8 @@ class GameIgdbSearch extends Component
             'cover_url' => $this->cover_url ?: null,
             'developer' => $this->developer ?: null,
             'publisher' => $this->publisher ?: null,
-            'platform' => ! empty($this->selectedPlatforms) ? $this->selectedPlatforms : null,
-            'genre' => ! empty($this->genre) ? $this->genre : null,
+            'platform' => $this->selectedPlatforms === [] ? null : $this->selectedPlatforms,
+            'genre' => $this->genre === [] ? null : $this->genre,
             'release_date' => $this->release_date,
             'status' => $this->status,
             'ownership' => $this->ownership,
@@ -258,7 +259,7 @@ class GameIgdbSearch extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.games.game-igdb-search', [
             'statuses' => PlayingStatus::cases(),

--- a/app/Livewire/Games/GameIndex.php
+++ b/app/Livewire/Games/GameIndex.php
@@ -9,6 +9,7 @@ use App\Enums\PlayingStatus;
 use App\Livewire\Concerns\WithAccentInsensitiveSearch;
 use App\Livewire\Concerns\WithIndexFiltering;
 use App\Models\Game;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
@@ -100,7 +101,7 @@ class GameIndex extends Component
     {
         if ($value) {
             $query = $this->buildQuery();
-            $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+            $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
         } else {
             $this->selected = [];
         }
@@ -127,16 +128,16 @@ class GameIndex extends Component
     {
         $query = Game::query()
             ->where('user_id', Auth::id())
-            ->when($this->status, function ($query) {
+            ->when($this->status, function ($query): void {
                 $query->where('status', $this->status);
             })
-            ->when($this->ownership, function ($query) {
+            ->when($this->ownership, function ($query): void {
                 $query->where('ownership', $this->ownership);
             })
-            ->when($this->platform, function ($query) {
+            ->when($this->platform, function ($query): void {
                 $query->whereJsonContains('platform', $this->platform);
             })
-            ->when($this->genre, function ($query) {
+            ->when($this->genre, function ($query): void {
                 $query->whereJsonContains('genre', $this->genre);
             });
 
@@ -148,7 +149,7 @@ class GameIndex extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $perPage = $this->viewMode === 'list' ? 25 : 18;
         $sortBy = $this->safeSortBy();

--- a/app/Livewire/Games/GameShow.php
+++ b/app/Livewire/Games/GameShow.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Games;
 
 use App\Models\Game;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -128,7 +129,7 @@ class GameShow extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.games.game-show');
     }

--- a/app/Livewire/Listening/ListeningIndex.php
+++ b/app/Livewire/Listening/ListeningIndex.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Listening;
 
+use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 
@@ -35,7 +36,7 @@ class ListeningIndex extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.listening.listening-index', [
             'subcategories' => $this->getSubcategories(),

--- a/app/Livewire/Movies/MovieForm.php
+++ b/app/Livewire/Movies/MovieForm.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Movies;
 
 use App\Enums\WatchingStatus;
 use App\Models\Movie;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -166,11 +167,11 @@ class MovieForm extends Component
 
     public function isEditing(): bool
     {
-        return $this->movie !== null && $this->movie->exists;
+        return $this->movie instanceof Movie && $this->movie->exists;
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.movies.movie-form', [
             'statuses' => $this->getStatuses(),

--- a/app/Livewire/Movies/MovieImport.php
+++ b/app/Livewire/Movies/MovieImport.php
@@ -6,11 +6,15 @@ namespace App\Livewire\Movies;
 
 use App\Models\User;
 use App\Services\ImdbImportService;
+use Exception;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use InvalidArgumentException;
 use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads;
+use RuntimeException;
 
 class MovieImport extends Component
 {
@@ -73,7 +77,7 @@ class MovieImport extends Component
             }
 
             $this->preview = $preview->count() > 0 ? $preview : null;
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             $this->addError('file', $e->getMessage());
             $this->file = null;
             $this->preview = null;
@@ -89,7 +93,7 @@ class MovieImport extends Component
             $content = $this->uploadedContent();
 
             if ($content === null) {
-                throw new \RuntimeException('Could not read the uploaded file.');
+                throw new RuntimeException('Could not read the uploaded file.');
             }
 
             $service = new ImdbImportService;
@@ -99,7 +103,7 @@ class MovieImport extends Component
                 $service->parseCSV($content),
                 $this->skipDuplicates
             );
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->importResult = [
                 'imported' => 0,
                 'skipped' => 0,
@@ -144,7 +148,7 @@ class MovieImport extends Component
         return $user;
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.movies.movie-import');
     }

--- a/app/Livewire/Movies/MovieIndex.php
+++ b/app/Livewire/Movies/MovieIndex.php
@@ -8,6 +8,7 @@ use App\Enums\WatchingStatus;
 use App\Livewire\Concerns\WithAccentInsensitiveSearch;
 use App\Livewire\Concerns\WithIndexFiltering;
 use App\Models\Movie;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
@@ -101,10 +102,10 @@ class MovieIndex extends Component
         if ($value) {
             $query = Movie::query()
                 ->where('user_id', Auth::id())
-                ->when($this->status, function ($query) {
+                ->when($this->status, function ($query): void {
                     $query->where('status', $this->status);
                 })
-                ->when($this->genre, function ($query) {
+                ->when($this->genre, function ($query): void {
                     $query->where('genres', 'like', '%'.$this->genre.'%');
                 });
 
@@ -112,9 +113,9 @@ class MovieIndex extends Component
 
             if ($this->search) {
                 $this->applyAccentInsensitiveSearch($query, $this->search, ['title', 'director', 'original_title']);
-                $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+                $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
             } else {
-                $this->selected = $query->pluck('id')->map(fn ($id) => is_scalar($id) ? (string) $id : '')->values()->all();
+                $this->selected = $query->pluck('id')->map(fn ($id): string => is_scalar($id) ? (string) $id : '')->values()->all();
             }
         } else {
             $this->selected = [];
@@ -147,7 +148,7 @@ class MovieIndex extends Component
         }
 
         if ($this->hideEpisodes) {
-            $query->where(function ($q) {
+            $query->where(function ($q): void {
                 $q->where('title_type', '!=', 'TV Episode')
                     ->orWhereNull('title_type');
             })->whereNull('season_number');
@@ -163,7 +164,7 @@ class MovieIndex extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $perPage = $this->viewMode === 'list' ? 25 : 18;
         $sortBy = $this->safeSortBy();
@@ -171,10 +172,10 @@ class MovieIndex extends Component
 
         $query = Movie::query()
             ->where('user_id', Auth::id())
-            ->when($this->status, function ($query) {
+            ->when($this->status, function ($query): void {
                 $query->where('status', $this->status);
             })
-            ->when($this->genre, function ($query) {
+            ->when($this->genre, function ($query): void {
                 $query->where('genres', 'like', '%'.$this->genre.'%');
             });
 
@@ -222,7 +223,7 @@ class MovieIndex extends Component
         // Build curated type list: "TV Shows" replaces the grouped TV types,
         // inserted alphabetically among the other types (first in the TV block)
         $hasTvShows = $rawTypes->intersect(self::TV_SHOW_TYPES)->isNotEmpty();
-        $otherTypes = $rawTypes->reject(fn ($t) => in_array($t, self::TV_SHOW_TYPES))->sort()->values();
+        $otherTypes = $rawTypes->reject(fn ($t): bool => in_array($t, self::TV_SHOW_TYPES))->sort()->values();
 
         $allTypes = collect();
         $tvShowsInserted = false;

--- a/app/Livewire/Movies/MovieMetadataEnrichment.php
+++ b/app/Livewire/Movies/MovieMetadataEnrichment.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace App\Livewire\Movies;
 
 use App\Jobs\FetchMovieMetadata;
+use App\Livewire\Concerns\WithMetadataEnrichment;
+use App\Livewire\Concerns\WithSourcePriority;
 use App\Models\Movie;
 use App\Services\TmdbService;
 use App\Services\TraktService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -16,8 +19,8 @@ use Livewire\Component;
 
 class MovieMetadataEnrichment extends Component
 {
-    use \App\Livewire\Concerns\WithMetadataEnrichment;
-    use \App\Livewire\Concerns\WithSourcePriority;
+    use WithMetadataEnrichment;
+    use WithSourcePriority;
 
     /** @var list<string> */
     public array $sourcePriority = ['current', 'trakt', 'tmdb'];
@@ -140,7 +143,7 @@ class MovieMetadataEnrichment extends Component
         $randomFunction = in_array(DB::getDriverName(), ['sqlite', 'pgsql']) ? 'RANDOM()' : 'RAND()';
         $this->moviesNeedingEnrichment = Movie::query()
             ->where('user_id', Auth::id())
-            ->where(function ($query) {
+            ->where(function ($query): void {
                 $query->whereNull('description')
                     ->orWhere('description', '')
                     ->orWhereNull('poster_url')
@@ -155,7 +158,7 @@ class MovieMetadataEnrichment extends Component
             })
             ->orderByRaw("metadata_fetched_at IS NULL DESC, {$randomFunction}")
             ->get(['id', 'title', 'title_type', 'director', 'imdb_id', 'year', 'description', 'poster_url', 'runtime_minutes', 'release_date', 'genres', 'season_number', 'episode_number', 'show_name', 'metadata_fetched_at'])
-            ->map(function ($movie) {
+            ->map(function (Movie $movie): array {
                 $missing = $this->getMissingFields($movie);
 
                 return [
@@ -180,11 +183,11 @@ class MovieMetadataEnrichment extends Component
                         'episode_number' => $movie->episode_number,
                     ],
                     'missing' => $missing,
-                    'has_missing' => ! empty($missing),
+                    'has_missing' => $missing !== [],
                 ];
             })
-            ->filter(fn ($movie) => (bool) $movie['has_missing'])
-            ->sortByDesc(fn ($movie) => count($movie['missing']))
+            ->filter(fn ($movie): bool => (bool) $movie['has_missing'])
+            ->sortByDesc(fn ($movie): int => count($movie['missing']))
             ->values()
             ->all();
 
@@ -232,7 +235,7 @@ class MovieMetadataEnrichment extends Component
         }
 
         $moviesToFetch = collect($this->moviesNeedingEnrichment)
-            ->filter(fn ($movie) => (bool) $movie['has_missing'])
+            ->filter(fn ($movie): bool => (bool) $movie['has_missing'])
             ->take($this->batchLimit)
             ->pluck('id')
             ->all();
@@ -395,7 +398,7 @@ class MovieMetadataEnrichment extends Component
 
     public function applyMetadata(): void
     {
-        if (! $this->reviewingMovieId || ! $this->reviewingMetadata || empty($this->selectedFields)) {
+        if (! $this->reviewingMovieId || ! $this->reviewingMetadata || $this->selectedFields === []) {
             $this->closeReviewModal();
 
             return;
@@ -413,7 +416,7 @@ class MovieMetadataEnrichment extends Component
 
         $updateData = $this->buildUpdateData();
 
-        if (! empty($updateData)) {
+        if ($updateData !== []) {
             $movie->update($updateData);
         }
 
@@ -477,7 +480,7 @@ class MovieMetadataEnrichment extends Component
     {
         if ($this->activeTab === 'tv') {
             return collect($this->moviesNeedingEnrichment)
-                ->filter(fn ($m) => in_array($m['title_type'] ?? '', ['TV Series', 'TV Mini Series', 'TV Episode'], true))
+                ->filter(fn ($m): bool => in_array($m['title_type'] ?? '', ['TV Series', 'TV Mini Series', 'TV Episode'], true))
                 ->values()
                 ->all();
         }
@@ -492,7 +495,7 @@ class MovieMetadataEnrichment extends Component
     public function getTvCount(): int
     {
         return collect($this->moviesNeedingEnrichment)
-            ->filter(fn ($m) => in_array($m['title_type'] ?? '', ['TV Series', 'TV Mini Series', 'TV Episode'], true))
+            ->filter(fn ($m): bool => in_array($m['title_type'] ?? '', ['TV Series', 'TV Mini Series', 'TV Episode'], true))
             ->count();
     }
 
@@ -511,7 +514,7 @@ class MovieMetadataEnrichment extends Component
         $orphans = Movie::query()
             ->where('user_id', $userId)
             ->where('title_type', 'TV Episode')
-            ->where(function ($query) use ($seriesTitles) {
+            ->where(function ($query) use ($seriesTitles): void {
                 $query->whereNull('show_name')
                     ->orWhere('show_name', '');
                 if (! empty($seriesTitles)) {
@@ -520,7 +523,7 @@ class MovieMetadataEnrichment extends Component
             })
             ->orderBy('title')
             ->get(['id', 'title', 'title_type', 'imdb_id', 'year', 'show_name', 'season_number', 'episode_number', 'poster_url'])
-            ->map(fn ($movie) => [
+            ->map(fn ($movie): array => [
                 'id' => $movie->id,
                 'title' => $movie->title,
                 'imdb_id' => $movie->imdb_id,
@@ -557,10 +560,10 @@ class MovieMetadataEnrichment extends Component
             $propagated = Movie::query()
                 ->where('user_id', Auth::id())
                 ->where('title_type', 'TV Episode')
-                ->where(function ($q) use ($titlePrefix) {
+                ->where(function ($q) use ($titlePrefix): void {
                     $q->where('title', 'like', $titlePrefix.':%');
                 })
-                ->where(function ($q) {
+                ->where(function ($q): void {
                     $q->whereNull('show_name')->orWhere('show_name', '');
                 })
                 ->update(['show_name' => $showName]);
@@ -577,7 +580,7 @@ class MovieMetadataEnrichment extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         if ($this->jobStatus && $this->jobStatus['status'] === 'running') {
             $this->refreshJobStatus();

--- a/app/Livewire/Movies/MovieSettings.php
+++ b/app/Livewire/Movies/MovieSettings.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Movies;
 
 use App\Models\Movie;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -73,7 +74,7 @@ class MovieSettings extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.movies.movie-settings');
     }

--- a/app/Livewire/Movies/MovieShow.php
+++ b/app/Livewire/Movies/MovieShow.php
@@ -7,7 +7,11 @@ namespace App\Livewire\Movies;
 use App\Enums\WatchingStatus;
 use App\Models\Movie;
 use App\Services\TmdbService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 
@@ -178,7 +182,7 @@ class MovieShow extends Component
             $updates['year'] = $this->fetchedMetadata['year'];
         }
 
-        if (! empty($updates)) {
+        if ($updates !== []) {
             $updates['metadata_fetched_at'] = now();
             $this->movie->update($updates);
 
@@ -226,12 +230,12 @@ class MovieShow extends Component
     }
 
     /**
-     * @return \Illuminate\Support\Collection<int, Movie>
+     * @return Collection<int, Movie>
      */
-    public function getSiblingEpisodes(): \Illuminate\Support\Collection
+    public function getSiblingEpisodes(): Collection
     {
         if (! $this->movie->isLikelyEpisode()) {
-            return new \Illuminate\Support\Collection;
+            return new Collection;
         }
 
         $query = Movie::where('user_id', $this->movie->user_id)
@@ -241,11 +245,11 @@ class MovieShow extends Component
         if ($this->movie->show_name) {
             $query->where('show_name', $this->movie->show_name);
         } else {
-            $prefix = \Illuminate\Support\Str::before($this->movie->title, ':');
+            $prefix = Str::before($this->movie->title, ':');
             if ($prefix !== $this->movie->title) {
                 $query->where('title', 'like', $prefix.':%');
             } else {
-                return new \Illuminate\Support\Collection;
+                return new Collection;
             }
         }
 
@@ -254,7 +258,7 @@ class MovieShow extends Component
             $query->where('season_number', $this->movie->season_number);
         }
 
-        $driver = \Illuminate\Support\Facades\DB::getDriverName();
+        $driver = DB::getDriverName();
         $nullLast = $driver === 'pgsql' ? 'NULLS LAST' : '';
 
         return $query
@@ -267,7 +271,7 @@ class MovieShow extends Component
     public function getShowName(): string
     {
         return $this->movie->show_name
-            ?? \Illuminate\Support\Str::before($this->movie->title, ':');
+            ?? Str::before($this->movie->title, ':');
     }
 
     public function getParentShow(): ?Movie
@@ -282,7 +286,7 @@ class MovieShow extends Component
         return Movie::where('user_id', $this->movie->user_id)
             ->where('id', '!=', $this->movie->id)
             ->whereIn('title_type', ['TV Series', 'TV Mini Series'])
-            ->where(function ($q) use ($showName) {
+            ->where(function ($q) use ($showName): void {
                 $q->where('title', $showName)
                     ->orWhere('show_name', $showName);
             })
@@ -290,7 +294,7 @@ class MovieShow extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $isSeries = in_array($this->movie->title_type, ['TV Series', 'TV Mini Series']);
         $allEpisodes = collect();

--- a/app/Livewire/Movies/MovieTmdbSearch.php
+++ b/app/Livewire/Movies/MovieTmdbSearch.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Movies;
 use App\Enums\WatchingStatus;
 use App\Models\Movie;
 use App\Services\TmdbService;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Layout;
@@ -91,7 +92,7 @@ class MovieTmdbSearch extends Component
             ->whereNotNull('season_number')
             ->whereNotNull('episode_number')
             ->get(['show_name', 'season_number', 'episode_number'])
-            ->map(fn ($m) => $m->show_name.'|'.$m->season_number.'|'.$m->episode_number)
+            ->map(fn ($m): string => $m->show_name.'|'.$m->season_number.'|'.$m->episode_number)
             ->all();
     }
 
@@ -229,7 +230,10 @@ class MovieTmdbSearch extends Component
         $tmdb = app(TmdbService::class);
         foreach ($this->seasons as $season) {
             $seasonNumber = is_array($season) ? $this->intOrNull($season['season_number'] ?? null) : null;
-            if ($seasonNumber === null || isset($this->loadedEpisodes[$seasonNumber])) {
+            if ($seasonNumber === null) {
+                continue;
+            }
+            if (isset($this->loadedEpisodes[$seasonNumber])) {
                 continue;
             }
             $episodes = $tmdb->fetchTVSeasonEpisodes($this->selectedTmdbId, $seasonNumber);
@@ -241,7 +245,7 @@ class MovieTmdbSearch extends Component
 
     public function selectAllEpisodes(): void
     {
-        if (empty($this->loadedEpisodes)) {
+        if ($this->loadedEpisodes === []) {
             $this->loadAllSeasons();
         }
 
@@ -257,7 +261,7 @@ class MovieTmdbSearch extends Component
 
     public function goToSelectEpisodes(): void
     {
-        if (empty($this->loadedEpisodes)) {
+        if ($this->loadedEpisodes === []) {
             $this->loadAllSeasons();
         }
         $this->step = 'select_episodes';
@@ -372,7 +376,7 @@ class MovieTmdbSearch extends Component
 
     public function importTVShow(): void
     {
-        if (empty($this->selectedEpisodes)) {
+        if ($this->selectedEpisodes === []) {
             session()->flash('error', 'No episodes selected.');
 
             return;
@@ -385,11 +389,11 @@ class MovieTmdbSearch extends Component
         $imported = 0;
         $skipped = 0;
 
-        DB::transaction(function () use ($userId, $showName, $posterUrl, $now, &$imported, &$skipped) {
+        DB::transaction(function () use ($userId, $showName, $posterUrl, $now, &$imported, &$skipped): void {
             // Create parent show entry if not already present
             $existingShow = Movie::where('user_id', $userId)
                 ->where('title_type', 'TV Series')
-                ->where(function ($q) use ($showName) {
+                ->where(function ($q) use ($showName): void {
                     $q->where('show_name', $showName)
                         ->orWhere('title', $showName);
                 })
@@ -417,7 +421,7 @@ class MovieTmdbSearch extends Component
             }
 
             // Create episode entries
-            foreach ($this->selectedEpisodes as $key => $_) {
+            foreach (array_keys($this->selectedEpisodes) as $key) {
                 if (! preg_match('/^S(\d+)E(\d+)$/', $key, $m)) {
                     continue;
                 }
@@ -506,7 +510,7 @@ class MovieTmdbSearch extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         $summary = $this->getSelectionSummaryProperty();
 

--- a/app/Livewire/Playing/PlayingIndex.php
+++ b/app/Livewire/Playing/PlayingIndex.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Playing;
 
+use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 
@@ -35,7 +36,7 @@ class PlayingIndex extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.playing.playing-index', [
             'subcategories' => $this->getSubcategories(),

--- a/app/Livewire/Reading/ReadingIndex.php
+++ b/app/Livewire/Reading/ReadingIndex.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\Livewire\Reading;
 
+use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 
 class ReadingIndex extends Component
 {
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.reading.reading-index', [
             'subcategories' => [

--- a/app/Livewire/ThemeSwitcher.php
+++ b/app/Livewire/ThemeSwitcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire;
 
 use App\Models\User;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
@@ -46,7 +47,7 @@ class ThemeSwitcher extends Component
         $this->dispatch('theme-changed', theme: $theme);
     }
 
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.theme-switcher', [
             'themes' => config('themes.available'),

--- a/app/Livewire/Watching/WatchingIndex.php
+++ b/app/Livewire/Watching/WatchingIndex.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Watching;
 
+use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 
@@ -35,7 +36,7 @@ class WatchingIndex extends Component
     }
 
     #[Layout('layouts.app')]
-    public function render(): \Illuminate\Contracts\View\View
+    public function render(): View
     {
         return view('livewire.watching.watching-index', [
             'subcategories' => $this->getSubcategories(),

--- a/app/Models/Album.php
+++ b/app/Models/Album.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Enums\CollectionStatus;
 use App\Enums\OwnershipStatus;
+use Database\Factories\AlbumFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -19,7 +20,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class Album extends Model
 {
-    /** @use HasFactory<\Database\Factories\AlbumFactory> */
+    /** @use HasFactory<AlbumFactory> */
     use HasFactory;
 
     protected $fillable = [

--- a/app/Models/Anime.php
+++ b/app/Models/Anime.php
@@ -5,21 +5,23 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\WatchingStatus;
+use Database\Factories\AnimeFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
 /**
  * @property WatchingStatus $status
- * @property \Illuminate\Support\Carbon|null $date_started
- * @property \Illuminate\Support\Carbon|null $date_finished
- * @property \Illuminate\Support\Carbon|null $date_added
- * @property \Illuminate\Support\Carbon|null $metadata_fetched_at
+ * @property Carbon|null $date_started
+ * @property Carbon|null $date_finished
+ * @property Carbon|null $date_added
+ * @property Carbon|null $metadata_fetched_at
  */
 class Anime extends Model
 {
-    /** @use HasFactory<\Database\Factories\AnimeFactory> */
+    /** @use HasFactory<AnimeFactory> */
     use HasFactory;
 
     protected $table = 'anime';
@@ -108,8 +110,8 @@ class Anime extends Model
         }
 
         return collect(explode(',', $genres))
-            ->map(fn ($genre) => trim($genre))
-            ->filter(fn ($genre) => $genre !== '')
+            ->map(fn ($genre): string => trim((string) $genre))
+            ->filter(fn ($genre): bool => $genre !== '')
             ->values()
             ->all();
     }
@@ -125,8 +127,8 @@ class Anime extends Model
         }
 
         return collect(explode(',', $studios))
-            ->map(fn ($studio) => trim($studio))
-            ->filter(fn ($studio) => $studio !== '')
+            ->map(fn ($studio): string => trim((string) $studio))
+            ->filter(fn ($studio): bool => $studio !== '')
             ->values()
             ->all();
     }
@@ -159,9 +161,9 @@ class Anime extends Model
         return static::where('user_id', $userId)
             ->whereNotNull('genres')
             ->pluck('genres')
-            ->flatMap(fn ($s) => is_string($s) ? explode(',', $s) : [])
-            ->map(fn ($s) => trim($s))
-            ->filter(fn ($s) => $s !== '')
+            ->flatMap(fn ($s): array => is_string($s) ? explode(',', $s) : [])
+            ->map(fn ($s): string => trim((string) $s))
+            ->filter(fn ($s): bool => $s !== '')
             ->unique()
             ->sort()
             ->values()
@@ -176,9 +178,9 @@ class Anime extends Model
         return static::where('user_id', $userId)
             ->whereNotNull('studios')
             ->pluck('studios')
-            ->flatMap(fn ($s) => is_string($s) ? explode(',', $s) : [])
-            ->map(fn ($s) => trim($s))
-            ->filter(fn ($s) => $s !== '')
+            ->flatMap(fn ($s): array => is_string($s) ? explode(',', $s) : [])
+            ->map(fn ($s): string => trim((string) $s))
+            ->filter(fn ($s): bool => $s !== '')
             ->unique()
             ->sort()
             ->values()

--- a/app/Models/BoardGame.php
+++ b/app/Models/BoardGame.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\BoardGameStatus;
+use Database\Factories\BoardGameFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -15,7 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class BoardGame extends Model
 {
-    /** @use HasFactory<\Database\Factories\BoardGameFactory> */
+    /** @use HasFactory<BoardGameFactory> */
     use HasFactory;
 
     protected $fillable = [

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -5,22 +5,24 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\ReadingStatus;
+use Database\Factories\BookFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Carbon;
 
 /**
  * @property ReadingStatus $status
- * @property \Illuminate\Support\Carbon|null $published_date
- * @property \Illuminate\Support\Carbon|null $date_started
- * @property \Illuminate\Support\Carbon|null $date_finished
- * @property \Illuminate\Support\Carbon|null $date_added
+ * @property Carbon|null $published_date
+ * @property Carbon|null $date_started
+ * @property Carbon|null $date_finished
+ * @property Carbon|null $date_added
  */
 class Book extends Model
 {
-    /** @use HasFactory<\Database\Factories\BookFactory> */
+    /** @use HasFactory<BookFactory> */
     use HasFactory;
 
     protected $fillable = [
@@ -149,8 +151,8 @@ class Book extends Model
         }
 
         return collect(explode(',', $shelves))
-            ->map(fn ($tag) => trim($tag))
-            ->filter(fn ($tag) => $tag !== '' && ! in_array(strtolower($tag), self::$statusShelves))
+            ->map(fn ($tag): string => trim((string) $tag))
+            ->filter(fn ($tag): bool => $tag !== '' && ! in_array(strtolower((string) $tag), self::$statusShelves))
             ->values()
             ->all();
     }
@@ -195,9 +197,9 @@ class Book extends Model
         return static::where('user_id', $userId)
             ->whereNotNull('shelves')
             ->pluck('shelves')
-            ->flatMap(fn ($s) => is_string($s) ? explode(',', $s) : [])
-            ->map(fn ($s) => trim($s))
-            ->filter(fn ($s) => $s !== '' && ! in_array(strtolower($s), self::$statusShelves))
+            ->flatMap(fn ($s): array => is_string($s) ? explode(',', $s) : [])
+            ->map(fn ($s): string => trim((string) $s))
+            ->filter(fn ($s): bool => $s !== '' && ! in_array(strtolower((string) $s), self::$statusShelves))
             ->unique()
             ->sort()
             ->values()

--- a/app/Models/Comic.php
+++ b/app/Models/Comic.php
@@ -5,22 +5,24 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\ReadingStatus;
+use Database\Factories\ComicFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 
 /**
  * @property ReadingStatus $status
- * @property \Illuminate\Support\Carbon|null $date_started
- * @property \Illuminate\Support\Carbon|null $date_finished
- * @property \Illuminate\Support\Carbon|null $date_added
- * @property \Illuminate\Support\Carbon|null $metadata_fetched_at
+ * @property Carbon|null $date_started
+ * @property Carbon|null $date_finished
+ * @property Carbon|null $date_added
+ * @property Carbon|null $metadata_fetched_at
  */
 class Comic extends Model
 {
-    /** @use HasFactory<\Database\Factories\ComicFactory> */
+    /** @use HasFactory<ComicFactory> */
     use HasFactory;
 
     protected $fillable = [
@@ -106,7 +108,7 @@ class Comic extends Model
             return [];
         }
 
-        return array_map('trim', explode(',', $creators));
+        return array_map(trim(...), explode(',', $creators));
     }
 
     /**
@@ -119,6 +121,6 @@ class Comic extends Model
             return [];
         }
 
-        return array_map('trim', explode(',', $characters));
+        return array_map(trim(...), explode(',', $characters));
     }
 }

--- a/app/Models/ComicIssue.php
+++ b/app/Models/ComicIssue.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\ReadingStatus;
+use Database\Factories\ComicIssueFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ComicIssue extends Model
 {
-    /** @use HasFactory<\Database\Factories\ComicIssueFactory> */
+    /** @use HasFactory<ComicIssueFactory> */
     use HasFactory;
 
     protected $fillable = [

--- a/app/Models/Concert.php
+++ b/app/Models/Concert.php
@@ -5,18 +5,20 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\ListeningStatus;
+use Database\Factories\ConcertFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
 /**
  * @property ListeningStatus $status
- * @property \Illuminate\Support\Carbon|null $event_date
+ * @property Carbon|null $event_date
  * @property array<int, mixed>|null $setlist
  */
 class Concert extends Model
 {
-    /** @use HasFactory<\Database\Factories\ConcertFactory> */
+    /** @use HasFactory<ConcertFactory> */
     use HasFactory;
 
     protected $fillable = [

--- a/app/Models/Episode.php
+++ b/app/Models/Episode.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Database\Factories\EpisodeFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Episode extends Model
 {
-    /** @use HasFactory<\Database\Factories\EpisodeFactory> */
+    /** @use HasFactory<EpisodeFactory> */
     use HasFactory;
 
     protected $fillable = [

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -6,22 +6,24 @@ namespace App\Models;
 
 use App\Enums\OwnershipStatus;
 use App\Enums\PlayingStatus;
+use Database\Factories\GameFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
 /**
  * @property PlayingStatus $status
  * @property OwnershipStatus $ownership
  * @property array<int, string>|null $platform
  * @property array<int, string>|null $genre
- * @property \Illuminate\Support\Carbon|null $release_date
- * @property \Illuminate\Support\Carbon|null $date_started
- * @property \Illuminate\Support\Carbon|null $date_finished
+ * @property Carbon|null $release_date
+ * @property Carbon|null $date_started
+ * @property Carbon|null $date_finished
  */
 class Game extends Model
 {
-    /** @use HasFactory<\Database\Factories\GameFactory> */
+    /** @use HasFactory<GameFactory> */
     use HasFactory;
 
     protected $fillable = [

--- a/app/Models/Movie.php
+++ b/app/Models/Movie.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\WatchingStatus;
+use Database\Factories\MovieFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 
 /**
  * @property string $title
@@ -25,15 +27,15 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string|null $notes
  * @property string|null $review
  * @property WatchingStatus $status
- * @property \Illuminate\Support\Carbon|null $release_date
- * @property \Illuminate\Support\Carbon|null $date_watched
- * @property \Illuminate\Support\Carbon|null $date_added
- * @property \Illuminate\Support\Carbon|null $date_rated
- * @property \Illuminate\Support\Carbon|null $metadata_fetched_at
+ * @property Carbon|null $release_date
+ * @property Carbon|null $date_watched
+ * @property Carbon|null $date_added
+ * @property Carbon|null $date_rated
+ * @property Carbon|null $metadata_fetched_at
  */
 class Movie extends Model
 {
-    /** @use HasFactory<\Database\Factories\MovieFactory> */
+    /** @use HasFactory<MovieFactory> */
     use HasFactory;
 
     protected $fillable = [
@@ -89,7 +91,7 @@ class Movie extends Model
 
     protected static function booted(): void
     {
-        static::saved(function (Movie $movie) {
+        static::saved(function (Movie $movie): void {
             if ($movie->isLikelyEpisode() && $movie->show_name) {
                 static::where('user_id', $movie->user_id)
                     ->where('title', $movie->show_name)
@@ -148,8 +150,8 @@ class Movie extends Model
         }
 
         return collect(explode(',', $genres))
-            ->map(fn ($genre) => trim($genre))
-            ->filter(fn ($genre) => $genre !== '')
+            ->map(fn ($genre): string => trim((string) $genre))
+            ->filter(fn ($genre): bool => $genre !== '')
             ->values()
             ->all();
     }
@@ -191,7 +193,11 @@ class Movie extends Model
 
     public function isLikelyEpisode(): bool
     {
-        return $this->isEpisode() || $this->title_type === 'TV Episode';
+        if ($this->isEpisode()) {
+            return true;
+        }
+
+        return $this->title_type === 'TV Episode';
     }
 
     /**
@@ -207,7 +213,7 @@ class Movie extends Model
         $query = static::where('user_id', $userId);
 
         if ($showName) {
-            $query->where(function ($q) use ($showName, $titlePrefix) {
+            $query->where(function ($q) use ($showName, $titlePrefix): void {
                 $q->where('show_name', $showName);
                 if ($titlePrefix) {
                     $q->orWhere('title', 'like', $titlePrefix.':%')
@@ -215,7 +221,7 @@ class Movie extends Model
                 }
             });
         } elseif ($titlePrefix) {
-            $query->where(function ($q) use ($titlePrefix) {
+            $query->where(function ($q) use ($titlePrefix): void {
                 $q->where('title', 'like', $titlePrefix.':%')
                     ->orWhere('title', $titlePrefix);
             });
@@ -244,9 +250,9 @@ class Movie extends Model
         return static::where('user_id', $userId)
             ->whereNotNull('genres')
             ->pluck('genres')
-            ->flatMap(fn ($s) => is_string($s) ? explode(',', $s) : [])
-            ->map(fn ($s) => trim($s))
-            ->filter(fn ($s) => $s !== '')
+            ->flatMap(fn ($s): array => is_string($s) ? explode(',', $s) : [])
+            ->map(fn ($s): string => trim((string) $s))
+            ->filter(fn ($s): bool => $s !== '')
             ->unique()
             ->sort()
             ->values()

--- a/app/Models/Shelf.php
+++ b/app/Models/Shelf.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Database\Factories\ShelfFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -12,7 +13,7 @@ use Illuminate\Support\Str;
 
 class Shelf extends Model
 {
-    /** @use HasFactory<\Database\Factories\ShelfFactory> */
+    /** @use HasFactory<ShelfFactory> */
     use HasFactory;
 
     protected $fillable = [
@@ -23,7 +24,7 @@ class Shelf extends Model
 
     protected static function booted(): void
     {
-        static::creating(function (Shelf $shelf) {
+        static::creating(function (Shelf $shelf): void {
             if (empty($shelf->slug)) {
                 $shelf->slug = Str::slug($shelf->name);
             }

--- a/app/Models/Show.php
+++ b/app/Models/Show.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\WatchingStatus;
+use Database\Factories\ShowFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -13,7 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Show extends Model
 {
-    /** @use HasFactory<\Database\Factories\ShowFactory> */
+    /** @use HasFactory<ShowFactory> */
     use HasFactory;
 
     protected $fillable = [
@@ -100,8 +101,8 @@ class Show extends Model
         }
 
         return collect(explode(',', $genres))
-            ->map(fn ($genre) => trim($genre))
-            ->filter(fn ($genre) => $genre !== '')
+            ->map(fn ($genre): string => trim((string) $genre))
+            ->filter(fn ($genre): bool => $genre !== '')
             ->values()
             ->all();
     }
@@ -114,9 +115,9 @@ class Show extends Model
         return static::where('user_id', $userId)
             ->whereNotNull('genres')
             ->pluck('genres')
-            ->flatMap(fn ($s) => is_string($s) ? explode(',', $s) : [])
-            ->map(fn ($s) => trim($s))
-            ->filter(fn ($s) => $s !== '')
+            ->flatMap(fn ($s): array => is_string($s) ? explode(',', $s) : [])
+            ->map(fn ($s): string => trim((string) $s))
+            ->filter(fn ($s): bool => $s !== '')
             ->unique()
             ->sort()
             ->values()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -12,7 +13,7 @@ use Illuminate\Notifications\Notifiable;
 
 class User extends Authenticatable
 {
-    /** @use HasFactory<\Database\Factories\UserFactory> */
+    /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -29,19 +31,19 @@ class AppServiceProvider extends ServiceProvider
 
         // Trust proxies from container/private networks only (Traefik/subpath)
         $trustedProxies = config('app.trusted_proxies', '');
-        \Illuminate\Http\Request::setTrustedProxies(
+        Request::setTrustedProxies(
             explode(',', is_string($trustedProxies) ? $trustedProxies : ''),
-            \Illuminate\Http\Request::HEADER_X_FORWARDED_FOR |
-            \Illuminate\Http\Request::HEADER_X_FORWARDED_HOST |
-            \Illuminate\Http\Request::HEADER_X_FORWARDED_PORT |
-            \Illuminate\Http\Request::HEADER_X_FORWARDED_PROTO |
-            \Illuminate\Http\Request::HEADER_X_FORWARDED_PREFIX
+            Request::HEADER_X_FORWARDED_FOR |
+            Request::HEADER_X_FORWARDED_HOST |
+            Request::HEADER_X_FORWARDED_PORT |
+            Request::HEADER_X_FORWARDED_PROTO |
+            Request::HEADER_X_FORWARDED_PREFIX
         );
 
         if ($this->app->environment('production')) {
-            \Illuminate\Support\Facades\URL::forceScheme('https');
+            URL::forceScheme('https');
             $appUrl = config('app.url');
-            \Illuminate\Support\Facades\URL::forceRootUrl(is_string($appUrl) ? $appUrl : null);
+            URL::forceRootUrl(is_string($appUrl) ? $appUrl : null);
         }
     }
 }

--- a/app/Services/BggService.php
+++ b/app/Services/BggService.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Services\Saloon\Bgg\BggConnector;
 use App\Services\Saloon\Bgg\Requests\GetBoardGameDetails;
 use App\Services\Saloon\Bgg\Requests\SearchBoardGames;
+use Exception;
 use SimpleXMLElement;
 
 class BggService
@@ -48,13 +49,13 @@ class BggService
                     $results[] = [
                         'bgg_id' => $id,
                         'title' => (string) $item->name['value'],
-                        'year_published' => isset($item->yearpublished) ? (int) $item->yearpublished['value'] : null,
+                        'year_published' => property_exists($item, 'yearpublished') && $item->yearpublished !== null ? (int) $item->yearpublished['value'] : null,
                     ];
                 }
             }
 
             return array_slice($results, 0, 20);
-        } catch (\Exception) {
+        } catch (Exception) {
             return [];
         }
     }
@@ -86,7 +87,7 @@ class BggService
                 }
             }
 
-            $coverUrl = isset($item->image) ? (string) $item->image : null;
+            $coverUrl = property_exists($item, 'image') && $item->image !== null ? (string) $item->image : null;
 
             $designers = [];
             $publishers = [];
@@ -106,7 +107,7 @@ class BggService
             }
 
             $bggRating = null;
-            if (isset($item->statistics->ratings->average)) {
+            if (property_exists($item->statistics->ratings, 'average') && $item->statistics->ratings->average !== null) {
                 $avg = (float) $item->statistics->ratings->average['value'];
                 if ($avg > 0) {
                     $bggRating = round($avg, 2);
@@ -116,18 +117,18 @@ class BggService
             return [
                 'bgg_id' => $bggId,
                 'title' => $title ?? 'Unknown',
-                'description' => isset($item->description) ? html_entity_decode(strip_tags((string) $item->description)) : null,
+                'description' => property_exists($item, 'description') && $item->description !== null ? html_entity_decode(strip_tags((string) $item->description)) : null,
                 'cover_url' => $coverUrl,
-                'year_published' => isset($item->yearpublished) ? (int) $item->yearpublished['value'] : null,
-                'designer' => ! empty($designers) ? implode(', ', array_slice($designers, 0, 3)) : null,
-                'publisher' => ! empty($publishers) ? $publishers[0] : null,
-                'min_players' => isset($item->minplayers) ? (int) $item->minplayers['value'] : null,
-                'max_players' => isset($item->maxplayers) ? (int) $item->maxplayers['value'] : null,
-                'playing_time' => isset($item->playingtime) ? (int) $item->playingtime['value'] : null,
+                'year_published' => property_exists($item, 'yearpublished') && $item->yearpublished !== null ? (int) $item->yearpublished['value'] : null,
+                'designer' => $designers === [] ? null : implode(', ', array_slice($designers, 0, 3)),
+                'publisher' => $publishers === [] ? null : $publishers[0],
+                'min_players' => property_exists($item, 'minplayers') && $item->minplayers !== null ? (int) $item->minplayers['value'] : null,
+                'max_players' => property_exists($item, 'maxplayers') && $item->maxplayers !== null ? (int) $item->maxplayers['value'] : null,
+                'playing_time' => property_exists($item, 'playingtime') && $item->playingtime !== null ? (int) $item->playingtime['value'] : null,
                 'genres' => $genres,
                 'bgg_rating' => $bggRating,
             ];
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }

--- a/app/Services/ComicImportService.php
+++ b/app/Services/ComicImportService.php
@@ -8,7 +8,9 @@ use App\Enums\ReadingStatus;
 use App\Models\Comic;
 use App\Models\User;
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 
 class ComicImportService
 {
@@ -18,7 +20,7 @@ class ComicImportService
     public function parseCSV(string $content): Collection
     {
         $lines = explode("\n", $content);
-        $headers = array_map(fn ($h) => (string) $h, str_getcsv((string) array_shift($lines)));
+        $headers = array_map(fn ($h): string => (string) $h, str_getcsv(array_shift($lines)));
 
         /** @var Collection<int, array<string, mixed>> $comics */
         $comics = collect();
@@ -34,7 +36,7 @@ class ComicImportService
                 continue;
             }
 
-            $data = array_combine($headers, array_map(fn ($v) => $v === null ? null : (string) $v, $row));
+            $data = array_combine($headers, array_map(fn ($v): ?string => $v ?? null, $row));
 
             $comics->push($this->mapRowToComic($data));
         }
@@ -50,11 +52,11 @@ class ComicImportService
         $data = json_decode($content, true);
 
         if (! is_array($data)) {
-            throw new \InvalidArgumentException('Invalid JSON: expected an array of comics.');
+            throw new InvalidArgumentException('Invalid JSON: expected an array of comics.');
         }
 
         return collect($data)
-            ->map(fn ($item) => $this->mapJsonToComic(is_array($item) ? $item : []))
+            ->map(fn ($item): array => $this->mapJsonToComic(is_array($item) ? $item : []))
             ->values();
     }
 
@@ -67,8 +69,8 @@ class ComicImportService
         return [
             'title' => $row['Title'] ?? '',
             'publisher' => $row['Publisher'] ?? null,
-            'start_year' => ! empty($row['Start Year']) ? (int) $row['Start Year'] : null,
-            'issue_count' => ! empty($row['Issue Count']) ? (int) $row['Issue Count'] : null,
+            'start_year' => empty($row['Start Year']) ? null : (int) $row['Start Year'],
+            'issue_count' => empty($row['Issue Count']) ? null : (int) $row['Issue Count'],
             'status' => $this->mapStatus($row['Status'] ?? ''),
             'rating' => $this->parseRating($row['Rating'] ?? ''),
             'date_started' => $this->parseDate($row['Date Started'] ?? ''),
@@ -77,7 +79,7 @@ class ComicImportService
             'review' => $row['Review'] ?? null,
             'creators' => $row['Creators'] ?? null,
             'characters' => $row['Characters'] ?? null,
-            'comicvine_volume_id' => ! empty($row['ComicVine Volume ID']) ? $row['ComicVine Volume ID'] : null,
+            'comicvine_volume_id' => empty($row['ComicVine Volume ID']) ? null : $row['ComicVine Volume ID'],
         ];
     }
 
@@ -115,7 +117,7 @@ class ComicImportService
 
         try {
             return Carbon::parse($date)->format('Y-m-d');
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -157,9 +159,7 @@ class ComicImportService
                 ->select('comicvine_volume_id', 'title', 'publisher')
                 ->get();
             $existingIds['comicvine'] = $userComics->pluck('comicvine_volume_id')->filter()->flip()->all();
-            $existingIds['title_publisher'] = $userComics->map(function ($c) {
-                return strtolower(trim($c->title)).':'.strtolower(trim($c->publisher ?? ''));
-            })->flip()->all();
+            $existingIds['title_publisher'] = $userComics->map(fn ($c): string => strtolower(trim((string) $c->title)).':'.strtolower(trim($c->publisher ?? '')))->flip()->all();
         }
 
         foreach ($comics as $index => $comicData) {
@@ -192,7 +192,7 @@ class ComicImportService
                     $key = $this->titlePublisherKey($comicData);
                     $existingIds['title_publisher'][$key] = true;
                 }
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $errors[] = 'Row '.($index + 2).': '.$e->getMessage();
             }
         }

--- a/app/Services/ComicVineService.php
+++ b/app/Services/ComicVineService.php
@@ -8,6 +8,8 @@ use App\Services\Saloon\ComicVine\ComicVineConnector;
 use App\Services\Saloon\ComicVine\Requests\GetIssues;
 use App\Services\Saloon\ComicVine\Requests\GetVolumeDetails;
 use App\Services\Saloon\ComicVine\Requests\SearchVolumes;
+use Exception;
+use Illuminate\Support\Facades\Log;
 
 class ComicVineService
 {
@@ -47,15 +49,18 @@ class ComicVineService
 
             $volumes = [];
             foreach (is_array($data['results'] ?? null) ? $data['results'] : [] as $item) {
-                if (! is_array($item) || ($item['resource_type'] ?? '') !== 'volume') {
+                if (! is_array($item)) {
+                    continue;
+                }
+                if (($item['resource_type'] ?? '') !== 'volume') {
                     continue;
                 }
                 $volumes[] = $this->mapVolume($item);
             }
 
             return $volumes;
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('ComicVine API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('ComicVine API error: '.$e->getMessage());
 
             return [];
         }
@@ -93,8 +98,8 @@ class ComicVineService
             $volume['characters'] = $this->namesList($result['characters'] ?? null) ?: null;
 
             return $volume;
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('ComicVine API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('ComicVine API error: '.$e->getMessage());
 
             return null;
         }
@@ -153,8 +158,8 @@ class ComicVineService
 
                 // Rate limiting is handled by the connector via Saloon's rate limit plugin
             } while ($offset < $totalResults && $results !== [] && $page < $maxPages);
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('ComicVine API error during issue fetch: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('ComicVine API error during issue fetch: '.$e->getMessage());
         }
 
         return $allIssues;

--- a/app/Services/DiscogsService.php
+++ b/app/Services/DiscogsService.php
@@ -8,6 +8,7 @@ use App\Services\Saloon\Discogs\DiscogsConnector;
 use App\Services\Saloon\Discogs\Requests\GetMasterRelease;
 use App\Services\Saloon\Discogs\Requests\GetRelease;
 use App\Services\Saloon\Discogs\Requests\SearchReleases;
+use Exception;
 
 class DiscogsService
 {
@@ -46,7 +47,10 @@ class DiscogsService
 
                     $id = $result['id'] ?? null;
                     $seenKey = is_scalar($id) ? (string) $id : null;
-                    if ($seenKey === null || isset($seenIds[$seenKey])) {
+                    if ($seenKey === null) {
+                        continue;
+                    }
+                    if (isset($seenIds[$seenKey])) {
                         continue;
                     }
                     $seenIds[$seenKey] = true;
@@ -62,7 +66,7 @@ class DiscogsService
                         'cover_url' => $this->bestSearchImage($result),
                         'genre' => $result['genre'] ?? [],
                         'style' => $result['style'] ?? [],
-                        'format' => is_array($format) ? implode(', ', array_map(fn ($v) => is_scalar($v) ? (string) $v : '', $format)) : null,
+                        'format' => is_array($format) ? implode(', ', array_map(fn ($v): string => is_scalar($v) ? (string) $v : '', $format)) : null,
                         'label' => is_array($label) ? ($label[0] ?? null) : null,
                         'country' => $result['country'] ?? null,
                         'type' => $result['type'] ?? 'master',
@@ -71,7 +75,7 @@ class DiscogsService
             }
 
             return array_slice($results, 0, 30);
-        } catch (\Exception) {
+        } catch (Exception) {
             return [];
         }
     }
@@ -91,7 +95,7 @@ class DiscogsService
             $data = $response->json();
 
             return $this->normalizeRelease($data, 'master');
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -111,7 +115,7 @@ class DiscogsService
             $data = $response->json();
 
             return $this->normalizeRelease($data, 'release');
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }

--- a/app/Services/GoodReadsImportService.php
+++ b/app/Services/GoodReadsImportService.php
@@ -8,6 +8,7 @@ use App\Enums\ReadingStatus;
 use App\Models\Book;
 use App\Models\User;
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Support\Collection;
 
 class GoodReadsImportService
@@ -18,7 +19,7 @@ class GoodReadsImportService
     public function parseCSV(string $content): Collection
     {
         $lines = explode("\n", $content);
-        $headers = array_map(fn ($h) => (string) $h, str_getcsv((string) array_shift($lines)));
+        $headers = array_map(fn ($h): string => (string) $h, str_getcsv(array_shift($lines)));
 
         /** @var Collection<int, array<string, mixed>> $books */
         $books = collect();
@@ -34,7 +35,7 @@ class GoodReadsImportService
                 continue;
             }
 
-            $data = array_combine($headers, array_map(fn ($v) => $v === null ? null : (string) $v, $row));
+            $data = array_combine($headers, array_map(fn ($v): ?string => $v ?? null, $row));
 
             $books->push($this->mapRowToBook($data));
         }
@@ -56,7 +57,7 @@ class GoodReadsImportService
             'author' => $this->parseAuthor($row['Author'] ?? '', $row['Additional Authors'] ?? ''),
             'isbn' => $isbn,
             'isbn13' => $isbn13,
-            'page_count' => ! empty($row['Number of Pages']) ? (int) $row['Number of Pages'] : null,
+            'page_count' => empty($row['Number of Pages']) ? null : (int) $row['Number of Pages'],
             'published_date' => $this->parseYear($row['Year Published'] ?? $row['Original Publication Year'] ?? ''),
             'publisher' => $row['Publisher'] ?? null,
             'goodreads_id' => $row['Book Id'] ?? $row['Book ID'] ?? null,
@@ -73,7 +74,7 @@ class GoodReadsImportService
     {
         $authors = array_filter([trim($author), trim($additionalAuthors)]);
 
-        return ! empty($authors) ? implode(', ', $authors) : null;
+        return $authors === [] ? null : implode(', ', $authors);
     }
 
     protected function cleanIsbn(string $isbn): ?string
@@ -100,7 +101,7 @@ class GoodReadsImportService
 
         try {
             return Carbon::parse($date)->format('Y-m-d');
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -178,7 +179,7 @@ class GoodReadsImportService
                         }
                     }
                 }
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $errors[] = 'Row '.($index + 2).': '.$e->getMessage();
             }
         }

--- a/app/Services/GoogleBooksService.php
+++ b/app/Services/GoogleBooksService.php
@@ -6,6 +6,7 @@ namespace App\Services;
 
 use App\Services\Saloon\GoogleBooks\GoogleBooksConnector;
 use App\Services\Saloon\GoogleBooks\Requests\SearchVolumes;
+use Exception;
 
 class GoogleBooksService
 {
@@ -45,7 +46,7 @@ class GoogleBooksService
                 'total' => $totalItems,
                 'total_pages' => (int) ceil($totalItems / 20),
             ];
-        } catch (\Exception) {
+        } catch (Exception) {
             return ['results' => [], 'total' => 0, 'total_pages' => 0];
         }
     }

--- a/app/Services/IgdbService.php
+++ b/app/Services/IgdbService.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Services\Saloon\Igdb\IgdbConnector;
 use App\Services\Saloon\Igdb\Requests\GetGameDetails;
 use App\Services\Saloon\Igdb\Requests\SearchGames;
+use Exception;
 
 class IgdbService
 {
@@ -42,7 +43,7 @@ class IgdbService
                 'total' => count($results),
                 'total_pages' => count($results) < $perPage ? $page : $page + 1,
             ];
-        } catch (\Exception) {
+        } catch (Exception) {
             return ['results' => [], 'total' => 0, 'total_pages' => 0];
         }
     }
@@ -62,7 +63,7 @@ class IgdbService
             $first = $response->json()[0] ?? null;
 
             return is_array($first) ? $this->normalizeGame($first) : null;
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }

--- a/app/Services/ImdbImportService.php
+++ b/app/Services/ImdbImportService.php
@@ -10,8 +10,11 @@ use App\Models\Movie;
 use App\Models\Show;
 use App\Models\User;
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
+use RuntimeException;
 
 class ImdbImportService
 {
@@ -26,7 +29,7 @@ class ImdbImportService
         // Write content to a temporary stream
         $stream = fopen('php://memory', 'r+');
         if ($stream === false) {
-            throw new \RuntimeException('Could not open a memory stream to parse the CSV.');
+            throw new RuntimeException('Could not open a memory stream to parse the CSV.');
         }
         fwrite($stream, $content);
         rewind($stream);
@@ -36,12 +39,12 @@ class ImdbImportService
 
         if ($headerRow === false || ! $this->hasRequiredHeaders($headerRow)) {
             fclose($stream);
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Invalid IMDB CSV format. Expected headers like: Const, Your Rating, Date Rated, Title, URL, Title Type, IMDb Rating, Runtime (mins), Year, Genres, Num Votes, Release Date, Directors'
             );
         }
 
-        $headers = array_map(fn ($h) => (string) $h, $headerRow);
+        $headers = array_map(fn ($h): string => (string) $h, $headerRow);
 
         /** @var Collection<int, array<string, string|null>> $entries */
         $entries = collect();
@@ -58,7 +61,7 @@ class ImdbImportService
                 continue;
             }
 
-            $entries->push(array_combine($headers, array_map(fn ($v) => $v === null ? null : (string) $v, $row)));
+            $entries->push(array_combine($headers, array_map(fn ($v): ?string => $v ?? null, $row)));
         }
 
         fclose($stream);
@@ -130,14 +133,14 @@ class ImdbImportService
         $mapped = [
             'type' => 'movie',
             'title' => $title,
-            'original_title' => ! empty($row['Original Title']) ? trim($row['Original Title']) : null,
-            'director' => ! empty($row['Directors']) ? trim($row['Directors']) : null,
-            'imdb_id' => ! empty($row['Const']) ? trim($row['Const']) : null,
-            'imdb_url' => ! empty($row['URL']) ? trim($row['URL']) : null,
-            'title_type' => ! empty($row['Title Type']) ? trim($row['Title Type']) : null,
+            'original_title' => empty($row['Original Title']) ? null : trim($row['Original Title']),
+            'director' => empty($row['Directors']) ? null : trim($row['Directors']),
+            'imdb_id' => empty($row['Const']) ? null : trim($row['Const']),
+            'imdb_url' => empty($row['URL']) ? null : trim($row['URL']),
+            'title_type' => empty($row['Title Type']) ? null : trim($row['Title Type']),
             'year' => $this->parseYear($row['Year'] ?? ''),
             'runtime_minutes' => $this->parseRuntime($row['Runtime (mins)'] ?? ''),
-            'genres' => ! empty($row['Genres']) ? trim($row['Genres']) : null,
+            'genres' => empty($row['Genres']) ? null : trim($row['Genres']),
             'imdb_rating' => $this->parseImdbRating($row['IMDb Rating'] ?? ''),
             'num_votes' => $this->parseNumVotes($row['Num Votes'] ?? ''),
             'release_date' => $this->parseDate($row['Release Date'] ?? ''),
@@ -168,12 +171,12 @@ class ImdbImportService
         return [
             'type' => 'show',
             'title' => trim($row['Title'] ?? ''),
-            'original_title' => ! empty($row['Original Title']) ? trim($row['Original Title']) : null,
-            'imdb_id' => ! empty($row['Const']) ? trim($row['Const']) : null,
-            'imdb_url' => ! empty($row['URL']) ? trim($row['URL']) : null,
-            'title_type' => ! empty($row['Title Type']) ? trim($row['Title Type']) : null,
+            'original_title' => empty($row['Original Title']) ? null : trim($row['Original Title']),
+            'imdb_id' => empty($row['Const']) ? null : trim($row['Const']),
+            'imdb_url' => empty($row['URL']) ? null : trim($row['URL']),
+            'title_type' => empty($row['Title Type']) ? null : trim($row['Title Type']),
             'year' => $this->parseYear($row['Year'] ?? ''),
-            'genres' => ! empty($row['Genres']) ? trim($row['Genres']) : null,
+            'genres' => empty($row['Genres']) ? null : trim($row['Genres']),
             'imdb_rating' => $this->parseImdbRating($row['IMDb Rating'] ?? ''),
             'num_votes' => $this->parseNumVotes($row['Num Votes'] ?? ''),
             'release_date' => $this->parseDate($row['Release Date'] ?? ''),
@@ -198,11 +201,11 @@ class ImdbImportService
             'season_number' => $episodeInfo['season_number'],
             'episode_number' => $episodeInfo['episode_number'],
             'episode_title' => $episodeInfo['episode_title'],
-            'imdb_id' => ! empty($row['Const']) ? trim($row['Const']) : null,
-            'imdb_url' => ! empty($row['URL']) ? trim($row['URL']) : null,
-            'director' => ! empty($row['Directors']) ? trim($row['Directors']) : null,
+            'imdb_id' => empty($row['Const']) ? null : trim($row['Const']),
+            'imdb_url' => empty($row['URL']) ? null : trim($row['URL']),
+            'director' => empty($row['Directors']) ? null : trim($row['Directors']),
             'runtime_minutes' => $this->parseRuntime($row['Runtime (mins)'] ?? ''),
-            'genres' => ! empty($row['Genres']) ? trim($row['Genres']) : null,
+            'genres' => empty($row['Genres']) ? null : trim($row['Genres']),
             'imdb_rating' => $this->parseImdbRating($row['IMDb Rating'] ?? ''),
             'num_votes' => $this->parseNumVotes($row['Num Votes'] ?? ''),
             'release_date' => $this->parseDate($row['Release Date'] ?? ''),
@@ -232,7 +235,7 @@ class ImdbImportService
                     'show_name' => trim($matches[1]),
                     'season_number' => (int) $matches[2],
                     'episode_number' => (int) $matches[3],
-                    'episode_title' => ! empty($matches[4]) ? trim($matches[4]) : null,
+                    'episode_title' => empty($matches[4]) ? null : trim($matches[4]),
                 ];
             }
         }
@@ -316,7 +319,7 @@ class ImdbImportService
 
         try {
             return Carbon::parse($date)->format('Y-m-d');
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -432,7 +435,7 @@ class ImdbImportService
                         $existingImdbIds[$imdbKey] = $movie->id;
                     }
                 }
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $errors[] = 'Movie "'.$this->strOf($movieData['title']).'": '.$e->getMessage();
             }
         }
@@ -494,7 +497,7 @@ class ImdbImportService
                         $existingImdbIds[$imdbKey] = $show->id;
                     }
                 }
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $errors[] = 'Show "'.$this->strOf($showData['title']).'": '.$e->getMessage();
             }
         }
@@ -561,7 +564,7 @@ class ImdbImportService
                         $episodeIds[] = $episode->id;
                         $imported++;
                     }
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     $season = $episodeData['season_number'] ?? null;
                     $episodeNum = $episodeData['episode_number'] ?? null;
                     $seasonEp = ($season !== null && $episodeNum !== null)
@@ -596,7 +599,7 @@ class ImdbImportService
                 'status' => WatchingStatus::Watchlist->value,
                 'date_added' => now()->format('Y-m-d'),
             ]);
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }

--- a/app/Services/JikanService.php
+++ b/app/Services/JikanService.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Services\Saloon\Jikan\JikanConnector;
 use App\Services\Saloon\Jikan\Requests\GetAnimeDetails;
 use App\Services\Saloon\Jikan\Requests\SearchAnime;
+use Exception;
 
 class JikanService
 {
@@ -32,7 +33,7 @@ class JikanService
             $data = $response->json('data');
 
             return is_array($data) && $data !== [] ? $this->normalizeData($data) : null;
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -53,7 +54,7 @@ class JikanService
             $first = is_array($results) ? ($results[0] ?? null) : null;
 
             return is_array($first) ? $this->normalizeData($first) : null;
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }

--- a/app/Services/JsonImportService.php
+++ b/app/Services/JsonImportService.php
@@ -9,7 +9,9 @@ use App\Models\Book;
 use App\Models\Shelf;
 use App\Models\User;
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 
 class JsonImportService
 {
@@ -24,16 +26,16 @@ class JsonImportService
         $data = json_decode($content, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new \InvalidArgumentException('Invalid JSON: '.json_last_error_msg());
+            throw new InvalidArgumentException('Invalid JSON: '.json_last_error_msg());
         }
 
         if (! is_array($data)) {
-            throw new \InvalidArgumentException('Invalid format: JSON must be an array of books');
+            throw new InvalidArgumentException('Invalid format: JSON must be an array of books');
         }
 
         return collect($data)
             ->filter()
-            ->map(fn ($item) => $this->mapJsonToBook(is_array($item) ? $item : []))
+            ->map(fn ($item): array => $this->mapJsonToBook(is_array($item) ? $item : []))
             ->values();
     }
 
@@ -53,7 +55,7 @@ class JsonImportService
             'isbn' => $isbn,
             'isbn13' => $isbn13,
             'asin' => $asin !== '' ? $asin : null,
-            'cover_url' => ! empty($item['bookCover']) ? $item['bookCover'] : null,
+            'cover_url' => empty($item['bookCover']) ? null : $item['bookCover'],
             'page_count' => $this->toIntOrNull($item['num_pages'] ?? null) ?: null,
             'published_date' => $this->parseDate($this->strOf($item['date_pub'] ?? $item['date_pub__ed__'] ?? null)),
             'publisher' => null,
@@ -61,13 +63,13 @@ class JsonImportService
             'status' => $this->mapShelfToStatus($this->strOf($item['shelves'] ?? null)),
             'rating' => $this->parseRating($item['rating'] ?? null),
             'avg_rating' => $this->toFloatOrNull($item['avg_rating'] ?? null) ?: null,
-            'num_ratings' => ! empty($item['num_ratings']) ? $this->parseNumRatings($item['num_ratings']) : null,
+            'num_ratings' => empty($item['num_ratings']) ? null : $this->parseNumRatings($item['num_ratings']),
             'date_pub' => $item['date_pub'] ?? null,
             'date_pub_edition' => $item['date_pub__ed__'] ?? null,
             'date_started' => $this->parseDate($this->strOf($item['date_started'] ?? null)),
             'date_finished' => $this->parseDate($this->strOf($item['date_read'] ?? null)),
             'date_added' => $this->parseDate($this->strOf($item['date_added'] ?? null)),
-            'shelves' => ! empty($item['shelves']) ? $item['shelves'] : null,
+            'shelves' => empty($item['shelves']) ? null : $item['shelves'],
             'notes' => $item['notes'] ?? null,
             'review' => $item['review'] ?? null,
             'comments' => $this->toIntOrNull($item['comments'] ?? null) ?: null,
@@ -98,7 +100,7 @@ class JsonImportService
 
         try {
             return Carbon::parse($date)->format('Y-m-d');
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -149,11 +151,12 @@ class JsonImportService
      */
     protected function extractCustomShelves(string $shelves): array
     {
-        $parts = array_map('trim', explode(',', $shelves));
+        $parts = array_map(trim(...), explode(',', $shelves));
 
         // Skip the first part (status) and filter out status keywords
         $customShelves = [];
-        for ($i = 1; $i < count($parts); $i++) {
+        $counter = count($parts);
+        for ($i = 1; $i < $counter; $i++) {
             $shelfName = trim($parts[$i]);
             $shelfLower = strtolower($shelfName);
 
@@ -185,7 +188,7 @@ class JsonImportService
             $existingIds['isbn13'] = $userBooks->pluck('isbn13')->filter()->flip()->all();
             $existingIds['isbn'] = $userBooks->pluck('isbn')->filter()->flip()->all();
             $existingIds['asin'] = $userBooks->pluck('asin')->filter()->flip()->all();
-            $existingIds['title_author'] = $userBooks->map(fn ($b) => strtolower($b->title.'|'.($b->author ?? '')))->flip()->all();
+            $existingIds['title_author'] = $userBooks->map(fn ($b): string => strtolower($b->title.'|'.($b->author ?? '')))->flip()->all();
         }
 
         foreach ($books as $index => $bookData) {
@@ -237,7 +240,7 @@ class JsonImportService
                 }
 
                 $imported++;
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $errors[] = 'Item '.($index + 1).': '.$e->getMessage();
             }
         }

--- a/app/Services/MalImportService.php
+++ b/app/Services/MalImportService.php
@@ -8,8 +8,12 @@ use App\Enums\WatchingStatus;
 use App\Models\Anime;
 use App\Models\User;
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+use RuntimeException;
+use SimpleXMLElement;
 
 class MalImportService
 {
@@ -24,17 +28,17 @@ class MalImportService
             ]);
 
         if (! $response->successful()) {
-            throw new \RuntimeException("Failed to fetch anime list for '{$username}'. MAL returned status {$response->status()}.");
+            throw new RuntimeException("Failed to fetch anime list for '{$username}'. MAL returned status {$response->status()}.");
         }
 
         $data = $response->json();
 
         if (! is_array($data)) {
-            throw new \RuntimeException("Unexpected response format from MAL for '{$username}'.");
+            throw new RuntimeException("Unexpected response format from MAL for '{$username}'.");
         }
 
         return collect($data)
-            ->map(fn ($entry) => $this->mapJsonEntryToAnime(is_array($entry) ? $entry : []))
+            ->map(fn ($entry): array => $this->mapJsonEntryToAnime(is_array($entry) ? $entry : []))
             ->values();
     }
 
@@ -46,7 +50,7 @@ class MalImportService
         $xml = simplexml_load_string($content, 'SimpleXMLElement', LIBXML_NOCDATA);
 
         if ($xml === false) {
-            throw new \InvalidArgumentException('Invalid XML format. Could not parse the MAL export file.');
+            throw new InvalidArgumentException('Invalid XML format. Could not parse the MAL export file.');
         }
 
         /** @var Collection<int, array<string, mixed>> $entries */
@@ -91,7 +95,7 @@ class MalImportService
             'mal_score' => $malScore > 0 ? $malScore : null,
             'mal_url' => $malId > 0 ? "https://myanimelist.net/anime/{$malId}" : null,
             'genres' => $genres ?: null,
-            'tags' => ! empty($entry['tags']) ? $entry['tags'] : null,
+            'tags' => empty($entry['tags']) ? null : $entry['tags'],
             'date_started' => $this->parseMalDateString(is_string($entry['start_date_string'] ?? null) ? $entry['start_date_string'] : null),
             'date_finished' => $this->parseMalDateString(is_string($entry['finish_date_string'] ?? null) ? $entry['finish_date_string'] : null),
         ];
@@ -100,7 +104,7 @@ class MalImportService
     /**
      * @return array<string, mixed>
      */
-    public function mapXmlEntryToAnime(\SimpleXMLElement $entry): array
+    public function mapXmlEntryToAnime(SimpleXMLElement $entry): array
     {
         $malStatus = (int) (string) $entry->my_status;
         $score = (int) (string) $entry->my_score;
@@ -182,7 +186,7 @@ class MalImportService
                 if ($skipDuplicates && $malKey !== null) {
                     $existingMalIds[$malKey] = true;
                 }
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $title = $animeData['title'];
                 $errors[] = '"'.(is_scalar($title) ? (string) $title : 'Unknown').'": '.$e->getMessage();
             }
@@ -243,7 +247,7 @@ class MalImportService
 
         try {
             return Carbon::parse($date)->format('Y-m-d');
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -256,7 +260,7 @@ class MalImportService
 
         try {
             return Carbon::parse($date)->format('Y-m-d');
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }

--- a/app/Services/OpenLibraryService.php
+++ b/app/Services/OpenLibraryService.php
@@ -9,6 +9,7 @@ use App\Services\Saloon\OpenLibrary\Requests\GetIsbnDetails;
 use App\Services\Saloon\OpenLibrary\Requests\GetWorkDetails;
 use App\Services\Saloon\OpenLibrary\Requests\SearchBooks;
 use Carbon\Carbon;
+use Exception;
 
 class OpenLibraryService
 {
@@ -71,7 +72,7 @@ class OpenLibraryService
                 'total' => $numFound,
                 'total_pages' => (int) ceil($numFound / 20),
             ];
-        } catch (\Exception) {
+        } catch (Exception) {
             return ['results' => [], 'total' => 0, 'total_pages' => 0];
         }
     }
@@ -101,7 +102,7 @@ class OpenLibraryService
             $workData = $this->fetchWorkData($editionData);
 
             return $this->normalizeData($editionData, $workData);
-        } catch (\Exception) {
+        } catch (Exception) {
             return null;
         }
     }
@@ -126,7 +127,7 @@ class OpenLibraryService
             if ($response->successful()) {
                 return $response->json();
             }
-        } catch (\Exception) {
+        } catch (Exception) {
             // Work data is optional
         }
 
@@ -193,7 +194,7 @@ class OpenLibraryService
             }
 
             return Carbon::parse($date)->format('Y-m-d');
-        } catch (\Exception) {
+        } catch (Exception) {
             if (preg_match('/(\d{4})/', $date, $matches)) {
                 return $matches[1].'-01-01';
             }

--- a/app/Services/Saloon/ComicVine/ComicVineConnector.php
+++ b/app/Services/Saloon/ComicVine/ComicVineConnector.php
@@ -6,6 +6,7 @@ namespace App\Services\Saloon\ComicVine;
 
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Cacheable;
+use Saloon\CachePlugin\Contracts\Driver;
 use Saloon\CachePlugin\Drivers\LaravelCacheDriver;
 use Saloon\CachePlugin\Traits\HasCaching;
 use Saloon\Http\Connector;
@@ -48,7 +49,7 @@ class ComicVineConnector extends Connector implements Cacheable
         ];
     }
 
-    public function resolveCacheDriver(): \Saloon\CachePlugin\Contracts\Driver
+    public function resolveCacheDriver(): Driver
     {
         return new LaravelCacheDriver(Cache::store());
     }

--- a/app/Services/Saloon/Discogs/DiscogsConnector.php
+++ b/app/Services/Saloon/Discogs/DiscogsConnector.php
@@ -6,6 +6,7 @@ namespace App\Services\Saloon\Discogs;
 
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Cacheable;
+use Saloon\CachePlugin\Contracts\Driver;
 use Saloon\CachePlugin\Drivers\LaravelCacheDriver;
 use Saloon\CachePlugin\Traits\HasCaching;
 use Saloon\Http\Connector;
@@ -38,7 +39,7 @@ class DiscogsConnector extends Connector implements Cacheable
         ];
     }
 
-    public function resolveCacheDriver(): \Saloon\CachePlugin\Contracts\Driver
+    public function resolveCacheDriver(): Driver
     {
         return new LaravelCacheDriver(Cache::store());
     }

--- a/app/Services/Saloon/GoogleBooks/GoogleBooksConnector.php
+++ b/app/Services/Saloon/GoogleBooks/GoogleBooksConnector.php
@@ -6,6 +6,7 @@ namespace App\Services\Saloon\GoogleBooks;
 
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Cacheable;
+use Saloon\CachePlugin\Contracts\Driver;
 use Saloon\CachePlugin\Drivers\LaravelCacheDriver;
 use Saloon\CachePlugin\Traits\HasCaching;
 use Saloon\Http\Connector;
@@ -34,7 +35,7 @@ class GoogleBooksConnector extends Connector implements Cacheable
         ];
     }
 
-    public function resolveCacheDriver(): \Saloon\CachePlugin\Contracts\Driver
+    public function resolveCacheDriver(): Driver
     {
         return new LaravelCacheDriver(Cache::store());
     }

--- a/app/Services/Saloon/Igdb/Requests/SearchGames.php
+++ b/app/Services/Saloon/Igdb/Requests/SearchGames.php
@@ -40,9 +40,6 @@ class SearchGames extends Request implements HasBody
             $body .= 'where platforms = ('.$this->platformId.'); ';
         }
 
-        $body .= 'limit '.$this->limit.'; '
-            .'offset '.$this->offset.';';
-
-        return $body;
+        return $body.('limit '.$this->limit.'; '.'offset '.$this->offset.';');
     }
 }

--- a/app/Services/Saloon/Jikan/JikanConnector.php
+++ b/app/Services/Saloon/Jikan/JikanConnector.php
@@ -6,6 +6,7 @@ namespace App\Services\Saloon\Jikan;
 
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Cacheable;
+use Saloon\CachePlugin\Contracts\Driver;
 use Saloon\CachePlugin\Drivers\LaravelCacheDriver;
 use Saloon\CachePlugin\Traits\HasCaching;
 use Saloon\Http\Connector;
@@ -39,7 +40,7 @@ class JikanConnector extends Connector implements Cacheable
         ];
     }
 
-    public function resolveCacheDriver(): \Saloon\CachePlugin\Contracts\Driver
+    public function resolveCacheDriver(): Driver
     {
         return new LaravelCacheDriver(Cache::store());
     }

--- a/app/Services/Saloon/OpenLibrary/OpenLibraryConnector.php
+++ b/app/Services/Saloon/OpenLibrary/OpenLibraryConnector.php
@@ -6,6 +6,7 @@ namespace App\Services\Saloon\OpenLibrary;
 
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Cacheable;
+use Saloon\CachePlugin\Contracts\Driver;
 use Saloon\CachePlugin\Drivers\LaravelCacheDriver;
 use Saloon\CachePlugin\Traits\HasCaching;
 use Saloon\Http\Connector;
@@ -34,7 +35,7 @@ class OpenLibraryConnector extends Connector implements Cacheable
         ];
     }
 
-    public function resolveCacheDriver(): \Saloon\CachePlugin\Contracts\Driver
+    public function resolveCacheDriver(): Driver
     {
         return new LaravelCacheDriver(Cache::store());
     }

--- a/app/Services/Saloon/SetlistFm/SetlistFmConnector.php
+++ b/app/Services/Saloon/SetlistFm/SetlistFmConnector.php
@@ -6,6 +6,7 @@ namespace App\Services\Saloon\SetlistFm;
 
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Cacheable;
+use Saloon\CachePlugin\Contracts\Driver;
 use Saloon\CachePlugin\Drivers\LaravelCacheDriver;
 use Saloon\CachePlugin\Traits\HasCaching;
 use Saloon\Http\Connector;
@@ -35,7 +36,7 @@ class SetlistFmConnector extends Connector implements Cacheable
         ];
     }
 
-    public function resolveCacheDriver(): \Saloon\CachePlugin\Contracts\Driver
+    public function resolveCacheDriver(): Driver
     {
         return new LaravelCacheDriver(Cache::store());
     }

--- a/app/Services/Saloon/Tmdb/TmdbConnector.php
+++ b/app/Services/Saloon/Tmdb/TmdbConnector.php
@@ -6,6 +6,7 @@ namespace App\Services\Saloon\Tmdb;
 
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Cacheable;
+use Saloon\CachePlugin\Contracts\Driver;
 use Saloon\CachePlugin\Drivers\LaravelCacheDriver;
 use Saloon\CachePlugin\Traits\HasCaching;
 use Saloon\Http\Connector;
@@ -59,7 +60,7 @@ class TmdbConnector extends Connector implements Cacheable
         return $query;
     }
 
-    public function resolveCacheDriver(): \Saloon\CachePlugin\Contracts\Driver
+    public function resolveCacheDriver(): Driver
     {
         return new LaravelCacheDriver(Cache::store());
     }

--- a/app/Services/SetlistFmService.php
+++ b/app/Services/SetlistFmService.php
@@ -8,6 +8,7 @@ use App\Services\Saloon\SetlistFm\Requests\GetArtistSetlists;
 use App\Services\Saloon\SetlistFm\Requests\SearchArtists;
 use App\Services\Saloon\SetlistFm\Requests\SearchSetlists;
 use App\Services\Saloon\SetlistFm\SetlistFmConnector;
+use Exception;
 
 class SetlistFmService
 {
@@ -47,7 +48,7 @@ class SetlistFmService
             }
 
             return $out;
-        } catch (\Exception) {
+        } catch (Exception) {
             return [];
         }
     }
@@ -72,7 +73,7 @@ class SetlistFmService
                 'page' => $data['page'] ?? 1,
                 'items_per_page' => $data['itemsPerPage'] ?? 20,
             ];
-        } catch (\Exception) {
+        } catch (Exception) {
             return ['setlists' => [], 'total' => 0];
         }
     }
@@ -92,7 +93,7 @@ class SetlistFmService
             $data = $response->json();
 
             return $this->normalizeSetlists($data['setlist'] ?? null);
-        } catch (\Exception) {
+        } catch (Exception) {
             return [];
         }
     }

--- a/app/Services/TmdbService.php
+++ b/app/Services/TmdbService.php
@@ -9,7 +9,9 @@ use App\Services\Saloon\Tmdb\Requests\GetMovieDetails;
 use App\Services\Saloon\Tmdb\Requests\GetTvDetails;
 use App\Services\Saloon\Tmdb\Requests\SearchMulti;
 use App\Services\Saloon\Tmdb\TmdbConnector;
+use Exception;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class TmdbService
 {
@@ -69,8 +71,8 @@ class TmdbService
             }
 
             return $isTV ? $this->fetchTVDetails($id) : $this->fetchMovieDetails($id);
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('TMDB API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('TMDB API error: '.$e->getMessage());
 
             return null;
         }
@@ -108,8 +110,8 @@ class TmdbService
             $id = is_array($first) ? $this->toInt($first['id'] ?? null) : null;
 
             return $id !== null ? $this->fetchMovieDetails($id) : null;
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('TMDB API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('TMDB API error: '.$e->getMessage());
 
             return null;
         }
@@ -130,8 +132,8 @@ class TmdbService
             }
 
             return $this->normalizeData($response->json());
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('TMDB API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('TMDB API error: '.$e->getMessage());
 
             return null;
         }
@@ -152,8 +154,8 @@ class TmdbService
             }
 
             return $this->normalizeData($response->json());
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('TMDB API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('TMDB API error: '.$e->getMessage());
 
             return null;
         }
@@ -199,8 +201,8 @@ class TmdbService
                 'episode_number' => $episode['episode_number'] ?? null,
                 'poster_url' => $this->imageUrl($showData['poster_path'] ?? null),
             ];
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('TMDB API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('TMDB API error: '.$e->getMessage());
 
             return null;
         }
@@ -229,8 +231,8 @@ class TmdbService
             $posterPath = is_array($first) ? ($first['poster_path'] ?? null) : null;
 
             return $this->imageUrl($posterPath);
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('TMDB API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('TMDB API error: '.$e->getMessage());
 
             return null;
         }
@@ -262,10 +264,10 @@ class TmdbService
             'original_title' => $data['original_title'] ?? $data['original_name'] ?? null,
             'year' => $year ?: null,
             'imdb_id' => $imdbId,
-            'description' => ! empty($data['overview']) ? $data['overview'] : null,
+            'description' => empty($data['overview']) ? null : $data['overview'],
             'poster_url' => $this->imageUrl($data['poster_path'] ?? null),
             'runtime_minutes' => $runtime,
-            'release_date' => ! empty($data['release_date']) ? $data['release_date'] : ($data['first_air_date'] ?? null),
+            'release_date' => empty($data['release_date']) ? $data['first_air_date'] ?? null : ($data['release_date']),
             'genres' => $this->extractGenres($data['genres'] ?? null),
             'director' => $this->extractDirector($data['credits'] ?? null),
         ];
@@ -318,8 +320,8 @@ class TmdbService
                 'total_pages' => $data['total_pages'] ?? 0,
                 'total_results' => $data['total_results'] ?? 0,
             ];
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('TMDB API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('TMDB API error: '.$e->getMessage());
 
             return ['results' => [], 'total_pages' => 0, 'total_results' => 0];
         }
@@ -352,7 +354,10 @@ class TmdbService
                     continue;
                 }
                 $num = $this->toInt($s['season_number'] ?? null);
-                if ($num === null || $num <= 0) {
+                if ($num === null) {
+                    continue;
+                }
+                if ($num <= 0) {
                     continue;
                 }
                 $seasons[] = [
@@ -366,8 +371,8 @@ class TmdbService
             $normalized['seasons'] = $seasons;
 
             return $normalized;
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('TMDB API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('TMDB API error: '.$e->getMessage());
 
             return null;
         }
@@ -410,8 +415,8 @@ class TmdbService
             }
 
             return $episodes;
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('TMDB API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('TMDB API error: '.$e->getMessage());
 
             return null;
         }
@@ -425,7 +430,10 @@ class TmdbService
 
         $names = [];
         foreach ($genres as $g) {
-            if (! is_array($g) || ! is_string($g['name'] ?? null)) {
+            if (! is_array($g)) {
+                continue;
+            }
+            if (! is_string($g['name'] ?? null)) {
                 continue;
             }
             $mapped = self::GENRE_MAP[$g['name']] ?? $g['name'];

--- a/app/Services/TraktService.php
+++ b/app/Services/TraktService.php
@@ -7,6 +7,8 @@ namespace App\Services;
 use App\Services\Saloon\Trakt\Requests\SearchByImdbId;
 use App\Services\Saloon\Trakt\Requests\SearchText;
 use App\Services\Saloon\Trakt\TraktConnector;
+use Exception;
+use Illuminate\Support\Facades\Log;
 
 class TraktService
 {
@@ -54,8 +56,8 @@ class TraktService
             }
 
             return $this->normalizeData($data, $type);
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('Trakt API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('Trakt API error: '.$e->getMessage());
 
             return null;
         }
@@ -94,8 +96,8 @@ class TraktService
             }
 
             return $this->normalizeData($data, $itemType);
-        } catch (\Exception $e) {
-            \Illuminate\Support\Facades\Log::warning('Trakt API error: '.$e->getMessage());
+        } catch (Exception $e) {
+            Log::warning('Trakt API error: '.$e->getMessage());
 
             return null;
         }
@@ -132,7 +134,7 @@ class TraktService
             'title' => $data['title'] ?? null,
             'original_title' => $data['original_title'] ?? null,
             'year' => $year ?: null,
-            'description' => ! empty($data['overview']) ? $data['overview'] : null,
+            'description' => empty($data['overview']) ? null : $data['overview'],
             'poster_url' => $this->extractPosterUrl($data),
             'runtime_minutes' => $runtime,
             'release_date' => $releaseDate,
@@ -158,7 +160,7 @@ class TraktService
 
         // Trakt returns relative paths like "media.trakt.tv/images/..."
         if (! str_starts_with($posterPath, 'http')) {
-            $posterPath = 'https://'.$posterPath;
+            return 'https://'.$posterPath;
         }
 
         return $posterPath;

--- a/database/factories/AnimeFactory.php
+++ b/database/factories/AnimeFactory.php
@@ -10,7 +10,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Anime>
+ * @extends Factory<Anime>
  */
 class AnimeFactory extends Factory
 {
@@ -22,7 +22,7 @@ class AnimeFactory extends Factory
 
         return [
             'user_id' => User::factory(),
-            'title' => fake()->sentence(rand(2, 5)),
+            'title' => fake()->sentence(random_int(2, 5)),
             'status' => $status,
             'rating' => $status === WatchingStatus::Watched ? fake()->optional(0.8)->numberBetween(1, 10) : null,
             'year' => fake()->optional(0.9)->numberBetween(1980, 2026),
@@ -40,17 +40,17 @@ class AnimeFactory extends Factory
 
     public function watchlist(): static
     {
-        return $this->state(fn () => ['status' => WatchingStatus::Watchlist, 'rating' => null]);
+        return $this->state(fn (): array => ['status' => WatchingStatus::Watchlist, 'rating' => null]);
     }
 
     public function watching(): static
     {
-        return $this->state(fn () => ['status' => WatchingStatus::Watching, 'rating' => null]);
+        return $this->state(fn (): array => ['status' => WatchingStatus::Watching, 'rating' => null]);
     }
 
     public function watched(): static
     {
-        return $this->state(fn () => [
+        return $this->state(fn (): array => [
             'status' => WatchingStatus::Watched,
             'rating' => fake()->numberBetween(1, 10),
             'date_finished' => fake()->dateTimeBetween('-6 months', 'now'),

--- a/database/factories/BookFactory.php
+++ b/database/factories/BookFactory.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Database\Factories;
 
 use App\Enums\ReadingStatus;
+use App\Models\Book;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Book>
+ * @extends Factory<Book>
  */
 class BookFactory extends Factory
 {
@@ -28,7 +29,7 @@ class BookFactory extends Factory
 
         return [
             'user_id' => User::factory(),
-            'title' => fake()->sentence(rand(2, 6)),
+            'title' => fake()->sentence(random_int(2, 6)),
             'author' => fake()->name(),
             'isbn' => fake()->optional(0.7)->isbn10(),
             'isbn13' => fake()->optional(0.7)->isbn13(),
@@ -48,7 +49,7 @@ class BookFactory extends Factory
 
     public function wantToRead(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'status' => ReadingStatus::WantToRead,
             'date_started' => null,
             'date_finished' => null,
@@ -58,7 +59,7 @@ class BookFactory extends Factory
 
     public function reading(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'status' => ReadingStatus::Reading,
             'date_started' => fake()->dateTimeBetween('-1 month', 'now'),
             'date_finished' => null,
@@ -68,7 +69,7 @@ class BookFactory extends Factory
 
     public function read(): static
     {
-        return $this->state(function (array $attributes) {
+        return $this->state(function (array $attributes): array {
             $dateStarted = fake()->dateTimeBetween('-1 year', '-1 month');
 
             return [

--- a/database/factories/ComicFactory.php
+++ b/database/factories/ComicFactory.php
@@ -10,7 +10,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Comic>
+ * @extends Factory<Comic>
  */
 class ComicFactory extends Factory
 {
@@ -22,7 +22,7 @@ class ComicFactory extends Factory
 
         return [
             'user_id' => User::factory(),
-            'title' => fake()->sentence(rand(2, 5)),
+            'title' => fake()->sentence(random_int(2, 5)),
             'publisher' => fake()->optional(0.6)->company(),
             'start_year' => fake()->optional(0.7)->numberBetween(1960, 2026),
             'issue_count' => fake()->optional(0.5)->numberBetween(1, 200),
@@ -36,17 +36,17 @@ class ComicFactory extends Factory
 
     public function wantToRead(): static
     {
-        return $this->state(fn () => ['status' => ReadingStatus::WantToRead, 'rating' => null]);
+        return $this->state(fn (): array => ['status' => ReadingStatus::WantToRead, 'rating' => null]);
     }
 
     public function reading(): static
     {
-        return $this->state(fn () => ['status' => ReadingStatus::Reading, 'rating' => null]);
+        return $this->state(fn (): array => ['status' => ReadingStatus::Reading, 'rating' => null]);
     }
 
     public function read(): static
     {
-        return $this->state(fn () => [
+        return $this->state(fn (): array => [
             'status' => ReadingStatus::Read,
             'rating' => fake()->numberBetween(1, 5),
             'date_finished' => fake()->dateTimeBetween('-6 months', 'now'),

--- a/database/factories/ComicIssueFactory.php
+++ b/database/factories/ComicIssueFactory.php
@@ -11,7 +11,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ComicIssue>
+ * @extends Factory<ComicIssue>
  */
 class ComicIssueFactory extends Factory
 {

--- a/database/factories/ShelfFactory.php
+++ b/database/factories/ShelfFactory.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Shelf>
+ * @extends Factory<Shelf>
  */
 class ShelfFactory extends Factory
 {
@@ -18,7 +18,7 @@ class ShelfFactory extends Factory
 
     public function definition(): array
     {
-        $name = fake()->unique()->words(rand(1, 3), true);
+        $name = fake()->unique()->words(random_int(1, 3), true);
 
         return [
             'user_id' => User::factory(),

--- a/database/factories/ShowFactory.php
+++ b/database/factories/ShowFactory.php
@@ -27,17 +27,17 @@ class ShowFactory extends Factory
 
     public function watchlist(): static
     {
-        return $this->state(fn () => ['status' => WatchingStatus::Watchlist, 'rating' => null]);
+        return $this->state(fn (): array => ['status' => WatchingStatus::Watchlist, 'rating' => null]);
     }
 
     public function watching(): static
     {
-        return $this->state(fn () => ['status' => WatchingStatus::Watching, 'rating' => null]);
+        return $this->state(fn (): array => ['status' => WatchingStatus::Watching, 'rating' => null]);
     }
 
     public function watched(): static
     {
-        return $this->state(fn () => [
+        return $this->state(fn (): array => [
             'status' => WatchingStatus::Watched,
             'rating' => $this->faker->numberBetween(1, 10),
         ]);

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {
@@ -39,7 +40,7 @@ class UserFactory extends Factory
      */
     public function unverified(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'email_verified_at' => null,
         ]);
     }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', function (Blueprint $table): void {
             $table->id();
             $table->string('name');
             $table->string('email')->unique();
@@ -23,13 +23,13 @@ return new class extends Migration
             $table->timestamps();
         });
 
-        Schema::create('password_reset_tokens', function (Blueprint $table) {
+        Schema::create('password_reset_tokens', function (Blueprint $table): void {
             $table->string('email')->primary();
             $table->string('token');
             $table->timestamp('created_at')->nullable();
         });
 
-        Schema::create('sessions', function (Blueprint $table) {
+        Schema::create('sessions', function (Blueprint $table): void {
             $table->string('id')->primary();
             $table->foreignId('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();

--- a/database/migrations/0001_01_01_000001_create_cache_table.php
+++ b/database/migrations/0001_01_01_000001_create_cache_table.php
@@ -13,13 +13,13 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('cache', function (Blueprint $table) {
+        Schema::create('cache', function (Blueprint $table): void {
             $table->string('key')->primary();
             $table->mediumText('value');
             $table->integer('expiration')->index();
         });
 
-        Schema::create('cache_locks', function (Blueprint $table) {
+        Schema::create('cache_locks', function (Blueprint $table): void {
             $table->string('key')->primary();
             $table->string('owner');
             $table->integer('expiration')->index();

--- a/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('jobs', function (Blueprint $table) {
+        Schema::create('jobs', function (Blueprint $table): void {
             $table->id();
             $table->string('queue')->index();
             $table->longText('payload');
@@ -23,7 +23,7 @@ return new class extends Migration
             $table->unsignedInteger('created_at');
         });
 
-        Schema::create('job_batches', function (Blueprint $table) {
+        Schema::create('job_batches', function (Blueprint $table): void {
             $table->string('id')->primary();
             $table->string('name');
             $table->integer('total_jobs');
@@ -36,7 +36,7 @@ return new class extends Migration
             $table->integer('finished_at')->nullable();
         });
 
-        Schema::create('failed_jobs', function (Blueprint $table) {
+        Schema::create('failed_jobs', function (Blueprint $table): void {
             $table->id();
             $table->string('uuid')->unique();
             $table->text('connection');

--- a/database/migrations/2026_01_23_232553_create_books_table.php
+++ b/database/migrations/2026_01_23_232553_create_books_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('books', function (Blueprint $table) {
+        Schema::create('books', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('title');

--- a/database/migrations/2026_01_24_123537_add_extended_metadata_to_books_table.php
+++ b/database/migrations/2026_01_24_123537_add_extended_metadata_to_books_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('books', function (Blueprint $table) {
+        Schema::table('books', function (Blueprint $table): void {
             // ISBN and identifiers
             $table->string('asin')->nullable()->after('isbn13')->index();
 
@@ -48,7 +48,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('books', function (Blueprint $table) {
+        Schema::table('books', function (Blueprint $table): void {
             $table->dropColumn([
                 'asin',
                 'avg_rating',

--- a/database/migrations/2026_01_24_170126_create_shelves_table.php
+++ b/database/migrations/2026_01_24_170126_create_shelves_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('shelves', function (Blueprint $table) {
+        Schema::create('shelves', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('name');
@@ -23,7 +23,7 @@ return new class extends Migration
             $table->unique(['user_id', 'slug']);
         });
 
-        Schema::create('book_shelf', function (Blueprint $table) {
+        Schema::create('book_shelf', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('book_id')->constrained()->cascadeOnDelete();
             $table->foreignId('shelf_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2026_01_24_181552_rename_date_finished_to_date_recorded.php
+++ b/database/migrations/2026_01_24_181552_rename_date_finished_to_date_recorded.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('books', function (Blueprint $table) {
+        Schema::table('books', function (Blueprint $table): void {
             $table->renameColumn('date_finished', 'date_recorded');
         });
     }
@@ -23,7 +23,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('books', function (Blueprint $table) {
+        Schema::table('books', function (Blueprint $table): void {
             $table->renameColumn('date_recorded', 'date_finished');
         });
     }

--- a/database/migrations/2026_01_25_000000_add_theme_to_users_table.php
+++ b/database/migrations/2026_01_25_000000_add_theme_to_users_table.php
@@ -10,14 +10,14 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->string('theme', 50)->default('normie')->after('remember_token');
         });
     }
 
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn('theme');
         });
     }

--- a/database/migrations/2026_01_25_181345_add_queue_position_to_books_table.php
+++ b/database/migrations/2026_01_25_181345_add_queue_position_to_books_table.php
@@ -10,14 +10,14 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('books', function (Blueprint $table) {
+        Schema::table('books', function (Blueprint $table): void {
             $table->unsignedInteger('queue_position')->nullable()->after('status');
         });
     }
 
     public function down(): void
     {
-        Schema::table('books', function (Blueprint $table) {
+        Schema::table('books', function (Blueprint $table): void {
             $table->dropColumn('queue_position');
         });
     }

--- a/database/migrations/2026_01_25_184137_add_reading_progress_to_books_table.php
+++ b/database/migrations/2026_01_25_184137_add_reading_progress_to_books_table.php
@@ -10,14 +10,14 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('books', function (Blueprint $table) {
+        Schema::table('books', function (Blueprint $table): void {
             $table->unsignedInteger('current_page')->nullable()->after('page_count');
         });
     }
 
     public function down(): void
     {
-        Schema::table('books', function (Blueprint $table) {
+        Schema::table('books', function (Blueprint $table): void {
             $table->dropColumn('current_page');
         });
     }

--- a/database/migrations/2026_02_07_000000_create_movies_table.php
+++ b/database/migrations/2026_02_07_000000_create_movies_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('movies', function (Blueprint $table) {
+        Schema::create('movies', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('title');

--- a/database/migrations/2026_02_07_164122_add_metadata_fetched_at_to_movies_table.php
+++ b/database/migrations/2026_02_07_164122_add_metadata_fetched_at_to_movies_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('movies', function (Blueprint $table) {
+        Schema::table('movies', function (Blueprint $table): void {
             $table->timestamp('metadata_fetched_at')->nullable()->after('review');
         });
     }
@@ -23,7 +23,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('movies', function (Blueprint $table) {
+        Schema::table('movies', function (Blueprint $table): void {
             $table->dropColumn('metadata_fetched_at');
         });
     }

--- a/database/migrations/2026_02_07_170000_create_shows_table.php
+++ b/database/migrations/2026_02_07_170000_create_shows_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('shows', function (Blueprint $table) {
+        Schema::create('shows', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('title');

--- a/database/migrations/2026_02_07_170001_create_episodes_table.php
+++ b/database/migrations/2026_02_07_170001_create_episodes_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('episodes', function (Blueprint $table) {
+        Schema::create('episodes', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('show_id')->constrained()->cascadeOnDelete();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2026_02_07_180000_add_episode_fields_to_movies_table.php
+++ b/database/migrations/2026_02_07_180000_add_episode_fields_to_movies_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('movies', function (Blueprint $table) {
+        Schema::table('movies', function (Blueprint $table): void {
             $table->string('show_name')->nullable()->after('title');
             $table->unsignedSmallInteger('season_number')->nullable()->after('show_name');
             $table->unsignedSmallInteger('episode_number')->nullable()->after('season_number');
@@ -19,7 +19,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::table('movies', function (Blueprint $table) {
+        Schema::table('movies', function (Blueprint $table): void {
             $table->dropColumn(['show_name', 'season_number', 'episode_number']);
         });
     }

--- a/database/migrations/2026_02_09_000001_create_anime_table.php
+++ b/database/migrations/2026_02_09_000001_create_anime_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('anime', function (Blueprint $table) {
+        Schema::create('anime', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('title');

--- a/database/migrations/2026_02_27_000001_create_comics_table.php
+++ b/database/migrations/2026_02_27_000001_create_comics_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('comics', function (Blueprint $table) {
+        Schema::create('comics', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('title');

--- a/database/migrations/2026_02_27_000002_create_comic_issues_table.php
+++ b/database/migrations/2026_02_27_000002_create_comic_issues_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('comic_issues', function (Blueprint $table) {
+        Schema::create('comic_issues', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('comic_id')->constrained()->cascadeOnDelete();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2026_03_14_122144_add_missing_indexes.php
+++ b/database/migrations/2026_03_14_122144_add_missing_indexes.php
@@ -10,22 +10,22 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('comic_issues', function (Blueprint $table) {
+        Schema::table('comic_issues', function (Blueprint $table): void {
             $table->index('comicvine_issue_id');
         });
 
-        Schema::table('episodes', function (Blueprint $table) {
+        Schema::table('episodes', function (Blueprint $table): void {
             $table->index('show_id');
         });
     }
 
     public function down(): void
     {
-        Schema::table('comic_issues', function (Blueprint $table) {
+        Schema::table('comic_issues', function (Blueprint $table): void {
             $table->dropIndex(['comicvine_issue_id']);
         });
 
-        Schema::table('episodes', function (Blueprint $table) {
+        Schema::table('episodes', function (Blueprint $table): void {
             $table->dropIndex(['show_id']);
         });
     }

--- a/database/migrations/2026_03_14_135935_rename_date_recorded_to_date_finished_in_books.php
+++ b/database/migrations/2026_03_14_135935_rename_date_recorded_to_date_finished_in_books.php
@@ -16,14 +16,14 @@ return new class extends Migration
             ->whereNot('status', 'read')
             ->update(['date_recorded' => null]);
 
-        Schema::table('books', function (Blueprint $table) {
+        Schema::table('books', function (Blueprint $table): void {
             $table->renameColumn('date_recorded', 'date_finished');
         });
     }
 
     public function down(): void
     {
-        Schema::table('books', function (Blueprint $table) {
+        Schema::table('books', function (Blueprint $table): void {
             $table->renameColumn('date_finished', 'date_recorded');
         });
     }

--- a/database/migrations/2026_03_21_123331_create_games_table.php
+++ b/database/migrations/2026_03_21_123331_create_games_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('games', function (Blueprint $table) {
+        Schema::create('games', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('title');

--- a/database/migrations/2026_03_21_200000_add_igdb_id_to_games_table.php
+++ b/database/migrations/2026_03_21_200000_add_igdb_id_to_games_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('games', function (Blueprint $table) {
+        Schema::table('games', function (Blueprint $table): void {
             $table->unsignedBigInteger('igdb_id')->nullable()->after('rawg_id');
             $table->index('igdb_id');
         });
@@ -23,7 +23,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::table('games', function (Blueprint $table) {
+        Schema::table('games', function (Blueprint $table): void {
             $table->dropIndex(['igdb_id']);
             $table->dropColumn('igdb_id');
         });

--- a/database/migrations/2026_03_21_201051_convert_game_genre_to_json.php
+++ b/database/migrations/2026_03_21_201051_convert_game_genre_to_json.php
@@ -13,8 +13,8 @@ return new class extends Migration
         $games = DB::table('games')->whereNotNull('genre')->get(['id', 'genre']);
 
         foreach ($games as $game) {
-            $genres = array_map('trim', explode(',', $game->genre));
-            $genres = array_values(array_filter($genres, fn ($g) => $g !== ''));
+            $genres = array_map(trim(...), explode(',', (string) $game->genre));
+            $genres = array_values(array_filter($genres, fn ($g): bool => $g !== ''));
 
             DB::table('games')
                 ->where('id', $game->id)
@@ -33,7 +33,7 @@ return new class extends Migration
         DB::statement('ALTER TABLE games ALTER COLUMN genre TYPE varchar(500) USING genre::varchar');
 
         foreach ($games as $game) {
-            $genres = json_decode($game->genre, true);
+            $genres = json_decode((string) $game->genre, true);
             if (is_array($genres)) {
                 DB::table('games')
                     ->where('id', $game->id)

--- a/database/migrations/2026_03_22_140000_create_board_games_table.php
+++ b/database/migrations/2026_03_22_140000_create_board_games_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('board_games', function (Blueprint $table) {
+        Schema::create('board_games', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('title');

--- a/database/migrations/2026_03_22_200000_create_concerts_table.php
+++ b/database/migrations/2026_03_22_200000_create_concerts_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('concerts', function (Blueprint $table) {
+        Schema::create('concerts', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('artist');

--- a/database/migrations/2026_03_22_210000_create_albums_table.php
+++ b/database/migrations/2026_03_22_210000_create_albums_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('albums', function (Blueprint $table) {
+        Schema::create('albums', function (Blueprint $table): void {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->string('title');

--- a/database/migrations/2026_03_28_180000_refactor_board_games_for_bgg.php
+++ b/database/migrations/2026_03_28_180000_refactor_board_games_for_bgg.php
@@ -18,7 +18,7 @@ return new class extends Migration
         DB::table('board_games')->where('status', 'mastered')->update(['status' => 'owned']);
         DB::table('board_games')->where('status', 'shelved')->update(['status' => 'previously_owned']);
 
-        Schema::table('board_games', function (Blueprint $table) {
+        Schema::table('board_games', function (Blueprint $table): void {
             $table->dropColumn(['date_started', 'date_finished', 'ownership']);
             $table->decimal('bgg_rating', 4, 2)->nullable()->after('rating');
         });
@@ -26,7 +26,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::table('board_games', function (Blueprint $table) {
+        Schema::table('board_games', function (Blueprint $table): void {
             $table->date('date_started')->nullable();
             $table->date('date_finished')->nullable();
             $table->string('ownership')->default('owned');

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,11 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\If_\ExplicitBoolCompareRector;
 use Rector\Config\RectorConfig;
+use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
+use RectorLaravel\Rector\ClassMethod\MakeModelAttributesAndScopesProtectedRector;
+use RectorLaravel\Rector\FuncCall\AppToResolveRector;
 use RectorLaravel\Rector\StaticCall\CarbonToDateFacadeRector;
 use RectorLaravel\Set\LaravelSetList;
 
@@ -29,4 +33,16 @@ return RectorConfig::configure()
     ->withSkip([
         // Carbon is used deliberately; don't rewrite it to the Date facade.
         CarbonToDateFacadeRector::class,
+        // Project convention (CLAUDE.md): resolve services via app(Service::class),
+        // not resolve().
+        AppToResolveRector::class,
+        // empty() is used idiomatically throughout; rewriting it to
+        // in_array($x, [null, '', '0'], true) is noisier, not clearer.
+        DisallowedEmptyRuleFixerRector::class,
+        // Eloquent accessors/scopes are kept public by convention (view/Livewire
+        // access); don't force them to protected.
+        MakeModelAttributesAndScopesProtectedRector::class,
+        // Prefer the concise truthy checks already used across the codebase over
+        // explicit `!== null` / `!== ''` comparisons.
+        ExplicitBoolCompareRector::class,
     ]);

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
 
-Route::middleware('guest')->group(function () {
+Route::middleware('guest')->group(function (): void {
     // Registration disabled — access via Liberapay support or self-hosting
     // Volt::route('register', 'pages.auth.register')
     //     ->name('register');
@@ -21,7 +21,7 @@ Route::middleware('guest')->group(function () {
         ->name('password.reset');
 });
 
-Route::middleware('auth')->group(function () {
+Route::middleware('auth')->group(function (): void {
     Volt::route('verify-email', 'pages.auth.verify-email')
         ->name('verification.notice');
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -5,6 +5,6 @@ declare(strict_types=1);
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
-Artisan::command('inspire', function () {
+Artisan::command('inspire', function (): void {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,13 @@ use App\Livewire\Books\BookSettings;
 use App\Livewire\Books\BookShow;
 use App\Livewire\Books\MetadataEnrichment;
 use App\Livewire\Books\ReadQueue;
+use App\Livewire\Comics\ComicForm;
+use App\Livewire\Comics\ComicImport;
+use App\Livewire\Comics\ComicIndex;
+use App\Livewire\Comics\ComicIssueShow;
+use App\Livewire\Comics\ComicSettings;
+use App\Livewire\Comics\ComicShow;
+use App\Livewire\Comics\ComicVineSearch;
 use App\Livewire\Concerts\ConcertForm;
 use App\Livewire\Concerts\ConcertIndex;
 use App\Livewire\Concerts\ConcertSetlistFmSearch;
@@ -48,14 +55,14 @@ use Illuminate\Support\Facades\Route;
 
 Route::view('/', 'welcome');
 
-Route::middleware(['auth', 'verified'])->group(function () {
+Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::get('dashboard', Dashboard::class)->name('dashboard');
 
     // Watching category
     Route::get('watching', WatchingIndex::class)->name('watching.index');
 
     // Movies
-    Route::prefix('movies')->name('movies.')->group(function () {
+    Route::prefix('movies')->name('movies.')->group(function (): void {
         Route::get('/', MovieIndex::class)->name('index');
         Route::get('/create', MovieForm::class)->name('create');
         Route::get('/import', MovieImport::class)->name('import');
@@ -67,7 +74,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     // Anime
-    Route::prefix('anime')->name('anime.')->group(function () {
+    Route::prefix('anime')->name('anime.')->group(function (): void {
         Route::get('/', AnimeIndex::class)->name('index');
         Route::get('/create', AnimeForm::class)->name('create');
         Route::get('/import', AnimeImport::class)->name('import');
@@ -81,7 +88,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('reading', ReadingIndex::class)->name('reading.index');
 
     // Books
-    Route::prefix('books')->name('books.')->group(function () {
+    Route::prefix('books')->name('books.')->group(function (): void {
         Route::get('/', BookIndex::class)->name('index');
         Route::get('/create', BookForm::class)->name('create');
         Route::get('/import', BookImport::class)->name('import');
@@ -97,7 +104,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('playing', PlayingIndex::class)->name('playing.index');
 
     // Games
-    Route::prefix('games')->name('games.')->group(function () {
+    Route::prefix('games')->name('games.')->group(function (): void {
         Route::get('/', GameIndex::class)->name('index');
         Route::get('/create', GameForm::class)->name('create');
         Route::get('/discover', GameIgdbSearch::class)->name('discover');
@@ -106,7 +113,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     // Board Games
-    Route::prefix('board-games')->name('board-games.')->group(function () {
+    Route::prefix('board-games')->name('board-games.')->group(function (): void {
         Route::get('/', BoardGameIndex::class)->name('index');
         Route::get('/create', BoardGameForm::class)->name('create');
         Route::get('/discover', BoardGameBggSearch::class)->name('discover');
@@ -118,7 +125,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('listening', ListeningIndex::class)->name('listening.index');
 
     // Concerts (Live)
-    Route::prefix('concerts')->name('concerts.')->group(function () {
+    Route::prefix('concerts')->name('concerts.')->group(function (): void {
         Route::get('/', ConcertIndex::class)->name('index');
         Route::get('/create', ConcertForm::class)->name('create');
         Route::get('/discover', ConcertSetlistFmSearch::class)->name('discover');
@@ -127,7 +134,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     // Albums (Collection)
-    Route::prefix('albums')->name('albums.')->group(function () {
+    Route::prefix('albums')->name('albums.')->group(function (): void {
         Route::get('/', AlbumIndex::class)->name('index');
         Route::get('/create', AlbumForm::class)->name('create');
         Route::get('/discover', AlbumDiscogsSearch::class)->name('discover');
@@ -136,15 +143,15 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     // Comics
-    Route::prefix('comics')->name('comics.')->group(function () {
-        Route::get('/', App\Livewire\Comics\ComicIndex::class)->name('index');
-        Route::get('/create', App\Livewire\Comics\ComicForm::class)->name('create');
-        Route::get('/import', App\Livewire\Comics\ComicImport::class)->name('import');
-        Route::get('/search-comicvine', App\Livewire\Comics\ComicVineSearch::class)->name('search-comicvine');
-        Route::get('/settings', App\Livewire\Comics\ComicSettings::class)->name('settings');
-        Route::get('/{comic}', App\Livewire\Comics\ComicShow::class)->name('show');
-        Route::get('/{comic}/issues/{issue}', App\Livewire\Comics\ComicIssueShow::class)->name('issues.show');
-        Route::get('/{comic}/edit', App\Livewire\Comics\ComicForm::class)->name('edit');
+    Route::prefix('comics')->name('comics.')->group(function (): void {
+        Route::get('/', ComicIndex::class)->name('index');
+        Route::get('/create', ComicForm::class)->name('create');
+        Route::get('/import', ComicImport::class)->name('import');
+        Route::get('/search-comicvine', ComicVineSearch::class)->name('search-comicvine');
+        Route::get('/settings', ComicSettings::class)->name('settings');
+        Route::get('/{comic}', ComicShow::class)->name('show');
+        Route::get('/{comic}/issues/{issue}', ComicIssueShow::class)->name('issues.show');
+        Route::get('/{comic}/edit', ComicForm::class)->name('edit');
     });
 });
 

--- a/tests/Feature/AnimeIndexTest.php
+++ b/tests/Feature/AnimeIndexTest.php
@@ -8,22 +8,22 @@ use App\Models\Anime;
 use App\Models\User;
 use Livewire\Livewire;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->user = User::factory()->create();
 });
 
-it('renders the anime index page', function () {
+it('renders the anime index page', function (): void {
     $this->actingAs($this->user)
         ->get(route('anime.index'))
         ->assertOk();
 });
 
-it('requires authentication', function () {
+it('requires authentication', function (): void {
     $this->get(route('anime.index'))
         ->assertRedirect(route('login'));
 });
 
-it('displays anime for the authenticated user', function () {
+it('displays anime for the authenticated user', function (): void {
     Anime::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'My Test Anime',
@@ -34,7 +34,7 @@ it('displays anime for the authenticated user', function () {
         ->assertSee('My Test Anime');
 });
 
-it('filters anime by status', function () {
+it('filters anime by status', function (): void {
     Anime::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Watching Anime',
@@ -53,7 +53,7 @@ it('filters anime by status', function () {
         ->assertDontSee('Watched Anime');
 });
 
-it('does not show other users anime', function () {
+it('does not show other users anime', function (): void {
     $otherUser = User::factory()->create();
     Anime::factory()->create([
         'user_id' => $otherUser->id,

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use App\Models\User;
 use Livewire\Volt\Volt;
 
-test('login screen can be rendered', function () {
+test('login screen can be rendered', function (): void {
     $response = $this->get('/login');
 
     $response
@@ -13,7 +13,7 @@ test('login screen can be rendered', function () {
         ->assertSeeVolt('pages.auth.login');
 });
 
-test('users can authenticate using the login screen', function () {
+test('users can authenticate using the login screen', function (): void {
     $user = User::factory()->create();
 
     $component = Volt::test('pages.auth.login')
@@ -29,7 +29,7 @@ test('users can authenticate using the login screen', function () {
     $this->assertAuthenticated();
 });
 
-test('users can not authenticate with invalid password', function () {
+test('users can not authenticate with invalid password', function (): void {
     $user = User::factory()->create();
 
     $component = Volt::test('pages.auth.login')
@@ -45,7 +45,7 @@ test('users can not authenticate with invalid password', function () {
     $this->assertGuest();
 });
 
-test('navigation menu can be rendered', function () {
+test('navigation menu can be rendered', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user);
@@ -57,7 +57,7 @@ test('navigation menu can be rendered', function () {
         ->assertSeeVolt('layout.navigation');
 });
 
-test('users can logout', function () {
+test('users can logout', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user);

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -7,7 +7,7 @@ use Illuminate\Auth\Events\Verified;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
 
-test('email verification screen can be rendered', function () {
+test('email verification screen can be rendered', function (): void {
     $user = User::factory()->unverified()->create();
 
     $response = $this->actingAs($user)->get('/verify-email');
@@ -15,7 +15,7 @@ test('email verification screen can be rendered', function () {
     $response->assertStatus(200);
 });
 
-test('email can be verified', function () {
+test('email can be verified', function (): void {
     $user = User::factory()->unverified()->create();
 
     Event::fake();
@@ -23,7 +23,7 @@ test('email can be verified', function () {
     $verificationUrl = URL::temporarySignedRoute(
         'verification.verify',
         now()->addMinutes(60),
-        ['id' => $user->id, 'hash' => sha1($user->email)]
+        ['id' => $user->id, 'hash' => sha1((string) $user->email)]
     );
 
     $response = $this->actingAs($user)->get($verificationUrl);
@@ -33,7 +33,7 @@ test('email can be verified', function () {
     $response->assertRedirect(route('dashboard', absolute: false).'?verified=1');
 });
 
-test('email is not verified with invalid hash', function () {
+test('email is not verified with invalid hash', function (): void {
     $user = User::factory()->unverified()->create();
 
     $verificationUrl = URL::temporarySignedRoute(

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -7,7 +7,7 @@ namespace Tests\Feature\Auth;
 use App\Models\User;
 use Livewire\Volt\Volt;
 
-test('confirm password screen can be rendered', function () {
+test('confirm password screen can be rendered', function (): void {
     $user = User::factory()->create();
 
     $response = $this->actingAs($user)->get('/confirm-password');
@@ -17,7 +17,7 @@ test('confirm password screen can be rendered', function () {
         ->assertStatus(200);
 });
 
-test('password can be confirmed', function () {
+test('password can be confirmed', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user);
@@ -32,7 +32,7 @@ test('password can be confirmed', function () {
         ->assertHasNoErrors();
 });
 
-test('password is not confirmed with invalid password', function () {
+test('password is not confirmed with invalid password', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user);

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -9,7 +9,7 @@ use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Notification;
 use Livewire\Volt\Volt;
 
-test('reset password link screen can be rendered', function () {
+test('reset password link screen can be rendered', function (): void {
     $response = $this->get('/forgot-password');
 
     $response
@@ -17,7 +17,7 @@ test('reset password link screen can be rendered', function () {
         ->assertStatus(200);
 });
 
-test('reset password link can be requested', function () {
+test('reset password link can be requested', function (): void {
     Notification::fake();
 
     $user = User::factory()->create();
@@ -29,7 +29,7 @@ test('reset password link can be requested', function () {
     Notification::assertSentTo($user, ResetPassword::class);
 });
 
-test('reset password screen can be rendered', function () {
+test('reset password screen can be rendered', function (): void {
     Notification::fake();
 
     $user = User::factory()->create();
@@ -38,7 +38,7 @@ test('reset password screen can be rendered', function () {
         ->set('email', $user->email)
         ->call('sendPasswordResetLink');
 
-    Notification::assertSentTo($user, ResetPassword::class, function ($notification) {
+    Notification::assertSentTo($user, ResetPassword::class, function ($notification): true {
         $response = $this->get('/reset-password/'.$notification->token);
 
         $response
@@ -49,7 +49,7 @@ test('reset password screen can be rendered', function () {
     });
 });
 
-test('password can be reset with valid token', function () {
+test('password can be reset with valid token', function (): void {
     Notification::fake();
 
     $user = User::factory()->create();
@@ -58,7 +58,7 @@ test('password can be reset with valid token', function () {
         ->set('email', $user->email)
         ->call('sendPasswordResetLink');
 
-    Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
+    Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user): true {
         $component = Volt::test('pages.auth.reset-password', ['token' => $notification->token])
             ->set('email', $user->email)
             ->set('password', 'password')

--- a/tests/Feature/Auth/PasswordUpdateTest.php
+++ b/tests/Feature/Auth/PasswordUpdateTest.php
@@ -8,7 +8,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Livewire\Volt\Volt;
 
-test('password can be updated', function () {
+test('password can be updated', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user);
@@ -26,7 +26,7 @@ test('password can be updated', function () {
     $this->assertTrue(Hash::check('new-password', $user->refresh()->password));
 });
 
-test('correct password must be provided to update password', function () {
+test('correct password must be provided to update password', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user);

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -6,13 +6,13 @@ namespace Tests\Feature\Auth;
 
 use Livewire\Volt\Volt;
 
-test('registration screen is disabled', function () {
+test('registration screen is disabled', function (): void {
     $response = $this->get('/register');
 
     $response->assertNotFound();
 });
 
-test('new users can register', function () {
+test('new users can register', function (): void {
     $component = Volt::test('pages.auth.register')
         ->set('name', 'Test User')
         ->set('email', 'test@example.com')

--- a/tests/Feature/BookIndexTest.php
+++ b/tests/Feature/BookIndexTest.php
@@ -8,22 +8,22 @@ use App\Models\Book;
 use App\Models\User;
 use Livewire\Livewire;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->user = User::factory()->create();
 });
 
-it('renders the book index page', function () {
+it('renders the book index page', function (): void {
     $this->actingAs($this->user)
         ->get(route('books.index'))
         ->assertOk();
 });
 
-it('requires authentication', function () {
+it('requires authentication', function (): void {
     $this->get(route('books.index'))
         ->assertRedirect(route('login'));
 });
 
-it('displays books for the authenticated user', function () {
+it('displays books for the authenticated user', function (): void {
     $book = Book::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'My Test Book',
@@ -34,7 +34,7 @@ it('displays books for the authenticated user', function () {
         ->assertSee('My Test Book');
 });
 
-it('filters books by status', function () {
+it('filters books by status', function (): void {
     Book::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Currently Reading Book',
@@ -53,7 +53,7 @@ it('filters books by status', function () {
         ->assertDontSee('Finished Book');
 });
 
-it('does not show other users books', function () {
+it('does not show other users books', function (): void {
     $otherUser = User::factory()->create();
     Book::factory()->create([
         'user_id' => $otherUser->id,

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -6,22 +6,22 @@ use App\Livewire\Dashboard;
 use App\Models\User;
 use Livewire\Livewire;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->user = User::factory()->create();
 });
 
-it('renders the dashboard', function () {
+it('renders the dashboard', function (): void {
     $this->actingAs($this->user)
         ->get(route('dashboard'))
         ->assertOk();
 });
 
-it('requires authentication', function () {
+it('requires authentication', function (): void {
     $this->get(route('dashboard'))
         ->assertRedirect(route('login'));
 });
 
-it('displays category cards', function () {
+it('displays category cards', function (): void {
     Livewire::actingAs($this->user)
         ->test(Dashboard::class)
         ->assertSee('Watching')
@@ -30,7 +30,7 @@ it('displays category cards', function () {
         ->assertSee('Listening');
 });
 
-it('shows all four category cards as active links', function () {
+it('shows all four category cards as active links', function (): void {
     Livewire::actingAs($this->user)
         ->test(Dashboard::class)
         ->assertSee('Watching')

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-it('returns a successful response', function () {
+it('returns a successful response', function (): void {
     $response = $this->get('/');
 
     $response->assertStatus(200);

--- a/tests/Feature/GoodReadsImportArtifactsTest.php
+++ b/tests/Feature/GoodReadsImportArtifactsTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 use App\Services\GoodReadsImportService;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->service = new GoodReadsImportService;
 });
 
-it('cleans ISBN with Excel-style artifacts', function () {
+it('cleans ISBN with Excel-style artifacts', function (): void {
     $csv = implode('
 ', [
         'Title,Author,ISBN,ISBN13,My Rating,Exclusive Shelf,Number of Pages,Year Published,Book Id',
@@ -22,7 +22,7 @@ it('cleans ISBN with Excel-style artifacts', function () {
     expect($books[0]['isbn13'])->toBe('9780743273565');
 });
 
-it('handles accent marks in titles (UTF-8)', function () {
+it('handles accent marks in titles (UTF-8)', function (): void {
     $csv = implode('
 ', [
         'Title,Author,ISBN,ISBN13,My Rating,Exclusive Shelf,Number of Pages,Year Published,Book Id',

--- a/tests/Feature/GoodReadsImportTest.php
+++ b/tests/Feature/GoodReadsImportTest.php
@@ -7,12 +7,12 @@ use App\Models\Book;
 use App\Models\User;
 use App\Services\GoodReadsImportService;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->service = new GoodReadsImportService;
     $this->user = User::factory()->create();
 });
 
-it('parses a valid GoodReads CSV', function () {
+it('parses a valid GoodReads CSV', function (): void {
     $csv = implode("\n", [
         'Title,Author,ISBN,ISBN13,My Rating,Exclusive Shelf,Number of Pages,Year Published,Book Id',
         'The Great Gatsby,F. Scott Fitzgerald,0743273567,9780743273565,4,read,180,1925,4671',
@@ -30,7 +30,7 @@ it('parses a valid GoodReads CSV', function () {
     expect($books[1]['status'])->toBe(ReadingStatus::Reading);
 });
 
-it('maps shelf names to correct statuses', function () {
+it('maps shelf names to correct statuses', function (): void {
     $csv = implode("\n", [
         'Title,Author,ISBN,ISBN13,My Rating,Exclusive Shelf,Number of Pages,Year Published,Book Id',
         'Book A,Author A,,,0,to-read,100,2020,1',
@@ -45,7 +45,7 @@ it('maps shelf names to correct statuses', function () {
     expect($books[2]['status'])->toBe(ReadingStatus::Reading);
 });
 
-it('imports books into the database', function () {
+it('imports books into the database', function (): void {
     $csv = implode("\n", [
         'Title,Author,ISBN,ISBN13,My Rating,Exclusive Shelf,Number of Pages,Year Published,Book Id',
         'Test Book,Test Author,1234567890,9781234567890,3,read,200,2020,99999',
@@ -64,7 +64,7 @@ it('imports books into the database', function () {
     ]);
 });
 
-it('detects duplicates by goodreads_id', function () {
+it('detects duplicates by goodreads_id', function (): void {
     Book::factory()->create([
         'user_id' => $this->user->id,
         'goodreads_id' => '99999',
@@ -82,7 +82,7 @@ it('detects duplicates by goodreads_id', function () {
     expect($result['skipped'])->toBe(1);
 });
 
-it('detects duplicates by isbn13', function () {
+it('detects duplicates by isbn13', function (): void {
     Book::factory()->create([
         'user_id' => $this->user->id,
         'isbn13' => '9781234567890',
@@ -100,7 +100,7 @@ it('detects duplicates by isbn13', function () {
     expect($result['skipped'])->toBe(1);
 });
 
-it('skips empty rows', function () {
+it('skips empty rows', function (): void {
     $csv = "Title,Author,ISBN,ISBN13,My Rating,Exclusive Shelf,Number of Pages,Year Published,Book Id\n\n\n";
 
     $books = $this->service->parseCSV($csv);
@@ -108,7 +108,7 @@ it('skips empty rows', function () {
     expect($books)->toHaveCount(0);
 });
 
-it('handles zero rating as null', function () {
+it('handles zero rating as null', function (): void {
     $csv = implode("\n", [
         'Title,Author,ISBN,ISBN13,My Rating,Exclusive Shelf,Number of Pages,Year Published,Book Id',
         'Unrated Book,Author,,,0,to-read,100,2020,1',

--- a/tests/Feature/JsonImportTest.php
+++ b/tests/Feature/JsonImportTest.php
@@ -7,12 +7,12 @@ use App\Models\Book;
 use App\Models\User;
 use App\Services\JsonImportService;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->service = new JsonImportService;
     $this->user = User::factory()->create();
 });
 
-it('parses valid JSON book data', function () {
+it('parses valid JSON book data', function (): void {
     $json = json_encode([
         [
             'title' => 'Test Book',
@@ -33,7 +33,7 @@ it('parses valid JSON book data', function () {
     expect($books->first()['rating'])->toBe(4);
 });
 
-it('maps shelves to correct statuses', function () {
+it('maps shelves to correct statuses', function (): void {
     $json = json_encode([
         ['title' => 'A', 'author' => 'X', 'shelves' => 'to-read'],
         ['title' => 'B', 'author' => 'Y', 'shelves' => 'currently-reading'],
@@ -47,7 +47,7 @@ it('maps shelves to correct statuses', function () {
     expect($books[2]['status'])->toBe(ReadingStatus::Read);
 });
 
-it('imports books into the database', function () {
+it('imports books into the database', function (): void {
     $json = json_encode([
         [
             'title' => 'Imported Book',
@@ -68,7 +68,7 @@ it('imports books into the database', function () {
     ]);
 });
 
-it('detects duplicates by isbn13', function () {
+it('detects duplicates by isbn13', function (): void {
     Book::factory()->create([
         'user_id' => $this->user->id,
         'isbn13' => '9781234567890',
@@ -90,7 +90,7 @@ it('detects duplicates by isbn13', function () {
     expect($result['skipped'])->toBe(1);
 });
 
-it('detects duplicates by title and author', function () {
+it('detects duplicates by title and author', function (): void {
     Book::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Same Title',
@@ -114,11 +114,11 @@ it('detects duplicates by title and author', function () {
     expect($result['skipped'])->toBe(1);
 });
 
-it('throws on invalid JSON', function () {
+it('throws on invalid JSON', function (): void {
     $this->service->parseJson('not json');
 })->throws(InvalidArgumentException::class);
 
-it('creates shelves from custom shelf data', function () {
+it('creates shelves from custom shelf data', function (): void {
     $json = json_encode([
         [
             'title' => 'Book With Shelf',

--- a/tests/Feature/MalImportTest.php
+++ b/tests/Feature/MalImportTest.php
@@ -7,12 +7,12 @@ use App\Models\Anime;
 use App\Models\User;
 use App\Services\MalImportService;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->service = new MalImportService;
     $this->user = User::factory()->create();
 });
 
-it('parses a valid MAL XML export', function () {
+it('parses a valid MAL XML export', function (): void {
     $xml = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <myanimelist>
@@ -60,7 +60,7 @@ XML;
     expect($entries[1]['date_finished'])->toBeNull();
 });
 
-it('maps MAL statuses correctly', function () {
+it('maps MAL statuses correctly', function (): void {
     $xml = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <myanimelist>
@@ -110,7 +110,7 @@ XML;
     expect($entries[2]['status'])->toBe(WatchingStatus::Watchlist);
 });
 
-it('imports anime into the database', function () {
+it('imports anime into the database', function (): void {
     $xml = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <myanimelist>
@@ -141,7 +141,7 @@ XML;
     ]);
 });
 
-it('detects duplicates by mal_id', function () {
+it('detects duplicates by mal_id', function (): void {
     Anime::factory()->create([
         'user_id' => $this->user->id,
         'mal_id' => 1,
@@ -172,11 +172,11 @@ XML;
     expect($result['skipped'])->toBe(1);
 });
 
-it('throws on invalid XML', function () {
+it('throws on invalid XML', function (): void {
     $this->service->parseXml('not xml at all');
 })->throws(Exception::class);
 
-it('handles zero score as null rating', function () {
+it('handles zero score as null rating', function (): void {
     $xml = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <myanimelist>

--- a/tests/Feature/MovieIndexTest.php
+++ b/tests/Feature/MovieIndexTest.php
@@ -8,22 +8,22 @@ use App\Models\Movie;
 use App\Models\User;
 use Livewire\Livewire;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->user = User::factory()->create();
 });
 
-it('renders the movie index page', function () {
+it('renders the movie index page', function (): void {
     $this->actingAs($this->user)
         ->get(route('movies.index'))
         ->assertOk();
 });
 
-it('requires authentication', function () {
+it('requires authentication', function (): void {
     $this->get(route('movies.index'))
         ->assertRedirect(route('login'));
 });
 
-it('displays movies for the authenticated user', function () {
+it('displays movies for the authenticated user', function (): void {
     Movie::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'My Test Movie',
@@ -34,7 +34,7 @@ it('displays movies for the authenticated user', function () {
         ->assertSee('My Test Movie');
 });
 
-it('filters movies by status', function () {
+it('filters movies by status', function (): void {
     Movie::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Watching Movie',
@@ -53,7 +53,7 @@ it('filters movies by status', function () {
         ->assertDontSee('Watched Movie');
 });
 
-it('does not show other users movies', function () {
+it('does not show other users movies', function (): void {
     $otherUser = User::factory()->create();
     Movie::factory()->create([
         'user_id' => $otherUser->id,

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use App\Models\User;
 use Livewire\Volt\Volt;
 
-test('profile page is displayed', function () {
+test('profile page is displayed', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user);
@@ -19,7 +19,7 @@ test('profile page is displayed', function () {
         ->assertSeeVolt('profile.delete-user-form');
 });
 
-test('profile information can be updated', function () {
+test('profile information can be updated', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user);
@@ -40,7 +40,7 @@ test('profile information can be updated', function () {
     $this->assertNull($user->email_verified_at);
 });
 
-test('email verification status is unchanged when the email address is unchanged', function () {
+test('email verification status is unchanged when the email address is unchanged', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user);
@@ -57,7 +57,7 @@ test('email verification status is unchanged when the email address is unchanged
     $this->assertNotNull($user->refresh()->email_verified_at);
 });
 
-test('user can delete their account', function () {
+test('user can delete their account', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user);
@@ -74,7 +74,7 @@ test('user can delete their account', function () {
     $this->assertNull($user->fresh());
 });
 
-test('correct password must be provided to delete account', function () {
+test('correct password must be provided to delete account', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user);

--- a/tests/Feature/SortSanitizationTest.php
+++ b/tests/Feature/SortSanitizationTest.php
@@ -13,11 +13,11 @@ use App\Models\Movie;
 use App\Models\User;
 use Livewire\Livewire;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->user = User::factory()->create();
 });
 
-it('sanitizes malicious sortDirection in BookIndex', function () {
+it('sanitizes malicious sortDirection in BookIndex', function (): void {
     Book::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Safe Book',
@@ -30,7 +30,7 @@ it('sanitizes malicious sortDirection in BookIndex', function () {
         ->assertHasNoErrors();
 });
 
-it('sanitizes malicious sortBy in BookIndex', function () {
+it('sanitizes malicious sortBy in BookIndex', function (): void {
     Book::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Safe Book',
@@ -43,7 +43,7 @@ it('sanitizes malicious sortBy in BookIndex', function () {
         ->assertHasNoErrors();
 });
 
-it('sanitizes malicious sortDirection in MovieIndex', function () {
+it('sanitizes malicious sortDirection in MovieIndex', function (): void {
     Movie::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Safe Movie',
@@ -56,7 +56,7 @@ it('sanitizes malicious sortDirection in MovieIndex', function () {
         ->assertHasNoErrors();
 });
 
-it('sanitizes malicious sortBy in MovieIndex', function () {
+it('sanitizes malicious sortBy in MovieIndex', function (): void {
     Movie::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Safe Movie',
@@ -69,7 +69,7 @@ it('sanitizes malicious sortBy in MovieIndex', function () {
         ->assertHasNoErrors();
 });
 
-it('sanitizes malicious sortDirection in AnimeIndex', function () {
+it('sanitizes malicious sortDirection in AnimeIndex', function (): void {
     Anime::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Safe Anime',
@@ -82,7 +82,7 @@ it('sanitizes malicious sortDirection in AnimeIndex', function () {
         ->assertHasNoErrors();
 });
 
-it('sanitizes malicious sortBy in AnimeIndex', function () {
+it('sanitizes malicious sortBy in AnimeIndex', function (): void {
     Anime::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Safe Anime',
@@ -95,7 +95,7 @@ it('sanitizes malicious sortBy in AnimeIndex', function () {
         ->assertHasNoErrors();
 });
 
-it('sanitizes malicious sortDirection in ComicIndex', function () {
+it('sanitizes malicious sortDirection in ComicIndex', function (): void {
     Comic::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Safe Comic',
@@ -108,7 +108,7 @@ it('sanitizes malicious sortDirection in ComicIndex', function () {
         ->assertHasNoErrors();
 });
 
-it('sanitizes malicious sortBy in ComicIndex', function () {
+it('sanitizes malicious sortBy in ComicIndex', function (): void {
     Comic::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Safe Comic',
@@ -121,7 +121,7 @@ it('sanitizes malicious sortBy in ComicIndex', function () {
         ->assertHasNoErrors();
 });
 
-it('allows valid sort columns in BookIndex', function () {
+it('allows valid sort columns in BookIndex', function (): void {
     Book::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Test Book',
@@ -135,7 +135,7 @@ it('allows valid sort columns in BookIndex', function () {
         ->assertHasNoErrors();
 });
 
-it('allows valid sort columns in ComicIndex', function () {
+it('allows valid sort columns in ComicIndex', function (): void {
     Comic::factory()->create([
         'user_id' => $this->user->id,
         'title' => 'Test Comic',

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -13,8 +16,8 @@ declare(strict_types=1);
 |
 */
 
-pest()->extend(Tests\TestCase::class)
-    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
     ->in('Feature');
 
 /*
@@ -28,9 +31,7 @@ pest()->extend(Tests\TestCase::class)
 |
 */
 
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
-});
+expect()->extend('toBeOne', fn () => $this->toBe(1));
 
 /*
 |--------------------------------------------------------------------------
@@ -43,7 +44,7 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
+function something(): void
 {
     // ..
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Testing\TestResponse;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -12,12 +13,8 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        \Illuminate\Testing\TestResponse::macro('assertSeeVolt', function ($component) {
-            return $this->assertSee($component);
-        });
+        TestResponse::macro('assertSeeVolt', fn ($component) => $this->assertSee($component));
 
-        \Illuminate\Testing\TestResponse::macro('assertSeeLivewire', function ($component) {
-            return $this->assertSee($component);
-        });
+        TestResponse::macro('assertSeeLivewire', fn ($component) => $this->assertSee($component));
     }
 }

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-test('that true is true', function () {
+test('that true is true', function (): void {
     expect(true)->toBeTrue();
 });

--- a/tests/Unit/ReadingStatusTest.php
+++ b/tests/Unit/ReadingStatusTest.php
@@ -4,24 +4,24 @@ declare(strict_types=1);
 
 use App\Enums\ReadingStatus;
 
-it('has correct labels for all cases', function () {
+it('has correct labels for all cases', function (): void {
     expect(ReadingStatus::WantToRead->label())->toBe('Want to Read');
     expect(ReadingStatus::Reading->label())->toBe('Currently Reading');
     expect(ReadingStatus::Read->label())->toBe('Read');
 });
 
-it('has correct colors for all cases', function () {
+it('has correct colors for all cases', function (): void {
     expect(ReadingStatus::WantToRead->color())->toBe('blue');
     expect(ReadingStatus::Reading->color())->toBe('yellow');
     expect(ReadingStatus::Read->color())->toBe('green');
 });
 
-it('has correct backing values', function () {
+it('has correct backing values', function (): void {
     expect(ReadingStatus::WantToRead->value)->toBe('want_to_read');
     expect(ReadingStatus::Reading->value)->toBe('reading');
     expect(ReadingStatus::Read->value)->toBe('read');
 });
 
-it('has exactly three cases', function () {
+it('has exactly three cases', function (): void {
     expect(ReadingStatus::cases())->toHaveCount(3);
 });

--- a/tests/Unit/WatchingStatusTest.php
+++ b/tests/Unit/WatchingStatusTest.php
@@ -4,24 +4,24 @@ declare(strict_types=1);
 
 use App\Enums\WatchingStatus;
 
-it('has correct labels for all cases', function () {
+it('has correct labels for all cases', function (): void {
     expect(WatchingStatus::Watchlist->label())->toBe('Watchlist');
     expect(WatchingStatus::Watching->label())->toBe('Watching');
     expect(WatchingStatus::Watched->label())->toBe('Watched');
 });
 
-it('has correct colors for all cases', function () {
+it('has correct colors for all cases', function (): void {
     expect(WatchingStatus::Watchlist->color())->toBe('purple');
     expect(WatchingStatus::Watching->color())->toBe('yellow');
     expect(WatchingStatus::Watched->color())->toBe('green');
 });
 
-it('has correct backing values', function () {
+it('has correct backing values', function (): void {
     expect(WatchingStatus::Watchlist->value)->toBe('watchlist');
     expect(WatchingStatus::Watching->value)->toBe('watching');
     expect(WatchingStatus::Watched->value)->toBe('watched');
 });
 
-it('has exactly three cases', function () {
+it('has exactly three cases', function (): void {
     expect(WatchingStatus::cases())->toHaveCount(3);
 });


### PR DESCRIPTION
Makes the **Rector (advisory)** CI job pass by applying the project's own Rector configuration, while **skipping the rules that conflict with documented conventions** or reduce readability.

## Skipped rules (with rationale, now in `rector.php`)
| Rule | Why skipped |
|------|-------------|
| `AppToResolveRector` | CLAUDE.md mandates `app(Service::class)` for service resolution |
| `DisallowedEmptyRuleFixerRector` | rewrites `empty($x)` → `in_array($x, [null,'','0'], true)` — noisier, not clearer; `empty()` is idiomatic here |
| `MakeModelAttributesAndScopesProtectedRector` | Eloquent accessors/scopes stay `public` (view/Livewire access) |
| `ExplicitBoolCompareRector` | keep the concise truthy checks already used throughout |

## What was applied (157 files, additive & safe)
- Closure / arrow / function return types (advances the type-coverage ratchet)
- `NullToStrictStringFuncCallArgRector` (guards null args to string funcs)
- dead-code removal, early returns, first-class callables, import-name shortening
- one manual touch-up: narrowed a closure Rector over-widened to `string|array` (str_replace on a string subject returns `string`)

## Verification
- ✅ `rector process --dry-run` is clean ("Rector is done!")
- ✅ PHPStan baseline **unchanged**; `composer quality` green
- ✅ All **91 tests** pass (235 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)