### PR TITLE
fix(books): don't bump updated_at when reordering the read queue

### DIFF
--- a/app/Livewire/Books/BookIndex.php
+++ b/app/Livewire/Books/BookIndex.php
@@ -89,14 +89,19 @@ class BookIndex extends Component
             'date_finished' => $status === 'read' && ! $book->date_finished ? now() : $book->date_finished,
         ]);
 
-        // Auto-remove from queue when marked as read
+        // Auto-remove from queue when marked as read. Queue reordering is
+        // organizational, so it must not bump updated_at — otherwise every
+        // shifted book jumps to the top of the "Recently Updated" sort.
         if ($status === 'read' && $book->queue_position !== null) {
             $oldPosition = $book->queue_position;
-            $book->update(['queue_position' => null]);
 
-            Book::where('user_id', Auth::id())
-                ->where('queue_position', '>', $oldPosition)
-                ->decrement('queue_position');
+            Book::withoutTimestamps(function () use ($book, $oldPosition) {
+                $book->update(['queue_position' => null]);
+
+                Book::where('user_id', Auth::id())
+                    ->where('queue_position', '>', $oldPosition)
+                    ->decrement('queue_position');
+            });
         }
     }
 

--- a/app/Livewire/Books/BookShow.php
+++ b/app/Livewire/Books/BookShow.php
@@ -61,7 +61,8 @@ class BookShow extends Component
             ->max('queue_position');
         $maxPosition = is_numeric($maxPosition) ? (int) $maxPosition : 0;
 
-        $this->book->update(['queue_position' => $maxPosition + 1]);
+        // Queue position is organizational, not content — don't bump updated_at.
+        Book::withoutTimestamps(fn () => $this->book->update(['queue_position' => $maxPosition + 1]));
         $this->book->refresh();
     }
 
@@ -70,13 +71,18 @@ class BookShow extends Component
         $this->authorize('update', $this->book);
 
         $oldPosition = $this->book->queue_position;
-        $this->book->update(['queue_position' => null]);
 
-        if ($oldPosition !== null) {
-            Book::where('user_id', Auth::id())
-                ->where('queue_position', '>', $oldPosition)
-                ->decrement('queue_position');
-        }
+        // Reordering the queue must not touch updated_at, or every shifted book
+        // would jump to the top of the "Recently Updated" sort on /books.
+        Book::withoutTimestamps(function () use ($oldPosition) {
+            $this->book->update(['queue_position' => null]);
+
+            if ($oldPosition !== null) {
+                Book::where('user_id', Auth::id())
+                    ->where('queue_position', '>', $oldPosition)
+                    ->decrement('queue_position');
+            }
+        });
 
         $this->book->refresh();
     }

--- a/app/Livewire/Books/ReadQueue.php
+++ b/app/Livewire/Books/ReadQueue.php
@@ -27,7 +27,8 @@ class ReadQueue extends Component
             ->max('queue_position');
         $maxPosition = is_numeric($maxPosition) ? (int) $maxPosition : 0;
 
-        $book->update(['queue_position' => $maxPosition + 1]);
+        // Queue position is organizational, not content — don't bump updated_at.
+        Book::withoutTimestamps(fn () => $book->update(['queue_position' => $maxPosition + 1]));
     }
 
     public function removeFromQueue(Book $book): void
@@ -35,14 +36,18 @@ class ReadQueue extends Component
         $this->authorize('update', $book);
 
         $oldPosition = $book->queue_position;
-        $book->update(['queue_position' => null]);
 
-        // Reorder remaining items
-        if ($oldPosition !== null) {
-            Book::where('user_id', Auth::id())
-                ->where('queue_position', '>', $oldPosition)
-                ->decrement('queue_position');
-        }
+        // Reordering must not touch updated_at, or shifted books jump to the
+        // top of the "Recently Updated" sort on /books.
+        Book::withoutTimestamps(function () use ($book, $oldPosition) {
+            $book->update(['queue_position' => null]);
+
+            if ($oldPosition !== null) {
+                Book::where('user_id', Auth::id())
+                    ->where('queue_position', '>', $oldPosition)
+                    ->decrement('queue_position');
+            }
+        });
     }
 
     public function moveUp(Book $book): void
@@ -58,8 +63,10 @@ class ReadQueue extends Component
             ->first();
 
         if ($swapWith) {
-            $swapWith->update(['queue_position' => $book->queue_position]);
-            $book->update(['queue_position' => $book->queue_position - 1]);
+            Book::withoutTimestamps(function () use ($book, $swapWith) {
+                $swapWith->update(['queue_position' => $book->queue_position]);
+                $book->update(['queue_position' => $book->queue_position - 1]);
+            });
         }
     }
 
@@ -76,8 +83,10 @@ class ReadQueue extends Component
             ->first();
 
         if ($swapWith) {
-            $swapWith->update(['queue_position' => $book->queue_position]);
-            $book->update(['queue_position' => $book->queue_position + 1]);
+            Book::withoutTimestamps(function () use ($book, $swapWith) {
+                $swapWith->update(['queue_position' => $book->queue_position]);
+                $book->update(['queue_position' => $book->queue_position + 1]);
+            });
         }
     }
 
@@ -89,12 +98,14 @@ class ReadQueue extends Component
             return;
         }
 
-        // Shift all items above down by 1
-        Book::where('user_id', Auth::id())
-            ->where('queue_position', '<', $book->queue_position)
-            ->increment('queue_position');
+        Book::withoutTimestamps(function () use ($book) {
+            // Shift all items above down by 1
+            Book::where('user_id', Auth::id())
+                ->where('queue_position', '<', $book->queue_position)
+                ->increment('queue_position');
 
-        $book->update(['queue_position' => 1]);
+            $book->update(['queue_position' => 1]);
+        });
     }
 
     public function moveToBottom(Book $book): void
@@ -113,12 +124,14 @@ class ReadQueue extends Component
             return;
         }
 
-        // Shift all items below up by 1
-        Book::where('user_id', Auth::id())
-            ->where('queue_position', '>', $book->queue_position)
-            ->decrement('queue_position');
+        Book::withoutTimestamps(function () use ($book, $maxPosition) {
+            // Shift all items below up by 1
+            Book::where('user_id', Auth::id())
+                ->where('queue_position', '>', $book->queue_position)
+                ->decrement('queue_position');
 
-        $book->update(['queue_position' => $maxPosition]);
+            $book->update(['queue_position' => $maxPosition]);
+        });
     }
 
     public function updateStatus(Book $book, string $status): void

--- a/tests/Feature/BookQueueTimestampTest.php
+++ b/tests/Feature/BookQueueTimestampTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ReadingStatus;
+use App\Livewire\Books\BookIndex;
+use App\Livewire\Books\ReadQueue;
+use App\Models\Book;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+/**
+ * Create `count` queued books (positions 1..count) whose updated_at is
+ * backdated to a known point, so we can detect any spurious "touch".
+ */
+function queuedBooks(User $user, int $count, Carbon\Carbon $backdatedTo): Illuminate\Support\Collection
+{
+    $books = collect(range(1, $count))->map(fn (int $position) => Book::factory()->wantToRead()->create([
+        'user_id' => $user->id,
+        'queue_position' => $position,
+    ]));
+
+    Book::withoutTimestamps(fn () => Book::whereIn('id', $books->pluck('id'))
+        ->update(['updated_at' => $backdatedTo]));
+
+    return $books->each->refresh();
+}
+
+it('does not bump other queued books updated_at when one is marked read', function () {
+    $past = now()->subDays(10);
+    [$first, $second, $third] = queuedBooks($this->user, 3, $past)->all();
+
+    // Marking the top-of-queue book read auto-removes it and re-numbers the rest.
+    Livewire::actingAs($this->user)
+        ->test(BookIndex::class)
+        ->call('updateStatus', $first->id, 'read');
+
+    $second->refresh();
+    $third->refresh();
+
+    // The shifted books were re-numbered...
+    expect($second->queue_position)->toBe(1)
+        ->and($third->queue_position)->toBe(2);
+
+    // ...but their updated_at must be untouched (this is the regression we fixed).
+    expect($second->updated_at->format('Y-m-d H:i:s'))->toBe($past->format('Y-m-d H:i:s'))
+        ->and($third->updated_at->format('Y-m-d H:i:s'))->toBe($past->format('Y-m-d H:i:s'));
+
+    // The book we actually changed *should* be updated for real.
+    $first->refresh();
+    expect($first->status)->toBe(ReadingStatus::Read)
+        ->and($first->queue_position)->toBeNull()
+        ->and($first->updated_at->timestamp)->toBeGreaterThan($past->timestamp);
+});
+
+it('does not bump other queued books updated_at when one is removed from the queue', function () {
+    $past = now()->subDays(10);
+    [$first, $second, $third] = queuedBooks($this->user, 3, $past)->all();
+
+    Livewire::actingAs($this->user)
+        ->test(ReadQueue::class)
+        ->call('removeFromQueue', $first->id);
+
+    $second->refresh();
+    $third->refresh();
+
+    expect($second->queue_position)->toBe(1)
+        ->and($third->queue_position)->toBe(2)
+        ->and($second->updated_at->format('Y-m-d H:i:s'))->toBe($past->format('Y-m-d H:i:s'))
+        ->and($third->updated_at->format('Y-m-d H:i:s'))->toBe($past->format('Y-m-d H:i:s'));
+});
+
+it('does not bump updated_at when reordering the queue', function () {
+    $past = now()->subDays(10);
+    [$first, $second, $third] = queuedBooks($this->user, 3, $past)->all();
+
+    // moveToTop exercises the mass increment() branch.
+    Livewire::actingAs($this->user)
+        ->test(ReadQueue::class)
+        ->call('moveToTop', $third->id);
+
+    $first->refresh();
+    $second->refresh();
+    $third->refresh();
+
+    // Positions reshuffled: the third book is now first.
+    expect($third->queue_position)->toBe(1)
+        ->and($first->queue_position)->toBe(2)
+        ->and($second->queue_position)->toBe(3);
+
+    // No book's updated_at was touched by the reorder.
+    expect($first->updated_at->format('Y-m-d H:i:s'))->toBe($past->format('Y-m-d H:i:s'))
+        ->and($second->updated_at->format('Y-m-d H:i:s'))->toBe($past->format('Y-m-d H:i:s'))
+        ->and($third->updated_at->format('Y-m-d H:i:s'))->toBe($past->format('Y-m-d H:i:s'));
+});


### PR DESCRIPTION
## Problem

Queue position is organizational, not content — but the mass increment/decrement and per-book updates used for queue ordering all stamped `updated_at`. So marking a book read (which auto-removes it from the queue and renumbers the rest) made **every shifted book jump to the top** of the default *Recently Updated* sort on `/books`.

## Fix

Wrap all queue-position mutations in `Book::withoutTimestamps()`. Genuine status/date/rating changes still bump `updated_at` as before. Adds a regression test covering reorder, mark-read, and remove-from-queue paths.

Rescued from the `feat/teal-2026-theme` branch where it was authored alongside unrelated UI work — landed here on its own so it isn't blocked on the rebrand.

## Verification
- `composer stan` → **[OK] No errors** (level max)
- `composer lint` (Pint) → pass
- `php artisan test` → **94 passed** (incl. 3 new `BookQueueTimestampTest` cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)