### PR TITLE
ci: auto-deploy main → prod (GHCR build + pull-deploy on gerty)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,3 +103,58 @@ jobs:
         DB_USERNAME: teal
         DB_PASSWORD: password
       run: php artisan test
+
+  # ---------------------------------------------------------------------------
+  # Build the production image, push to GHCR, and deploy to gerty.
+  # Runs only on push to main, only after quality + tests are green.
+  # Secrets stay on gerty (.env / .env.production); none are shipped from CI.
+  # ---------------------------------------------------------------------------
+  build-and-deploy:
+    name: Build & Deploy (prod)
+    needs: [quality, tests]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-prod
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push production image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: production
+          push: true
+          tags: |
+            ghcr.io/dotmavriq/teal:${{ github.sha }}
+            ghcr.io/dotmavriq/teal:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to gerty (pull image, backup DB, migrate-guard, restart)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.GERTY_HOST }}
+          username: ${{ secrets.GERTY_USER }}
+          key: ${{ secrets.GERTY_SSH_KEY }}
+          command_timeout: 15m
+          script: |
+            set -e
+            cd /opt/teal/app
+            git fetch origin main
+            git reset --hard origin/main
+            TEAL_TAG=${{ github.sha }} ./docker/deploy-prod.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -147,14 +147,21 @@ jobs:
 
       - name: Deploy to gerty (pull image, backup DB, migrate-guard, restart)
         uses: appleboy/ssh-action@v1
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_SHA: ${{ github.sha }}
         with:
           host: ${{ secrets.GERTY_HOST }}
           username: ${{ secrets.GERTY_USER }}
           key: ${{ secrets.GERTY_SSH_KEY }}
           command_timeout: 15m
+          envs: GHCR_USER,GHCR_TOKEN,GIT_SHA
           script: |
             set -e
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
             cd /opt/teal/app
             git fetch origin main
             git reset --hard origin/main
-            TEAL_TAG=${{ github.sha }} ./docker/deploy-prod.sh
+            TEAL_TAG="$GIT_SHA" ./docker/deploy-prod.sh
+            docker logout ghcr.io || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,9 @@ services:
   # Application: FrankenPHP + Laravel Octane
   # --------------------------------------------------------------------------
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
+    # Image is built + pushed by CI (.github/workflows). Deploys pull it; gerty
+    # never builds. TEAL_TAG is set to the commit SHA by docker/deploy-prod.sh.
+    image: ${TEAL_IMAGE:-ghcr.io/dotmavriq/teal}:${TEAL_TAG:-latest}
     container_name: teal-app
     restart: unless-stopped
     depends_on:
@@ -48,6 +47,8 @@ services:
       OCTANE_MAX_REQUESTS: "1000"
     volumes:
       - teal-storage:/var/www/html/storage/app/public
+      # Secrets live only on gerty; mounted read-only (never baked into the image)
+      - ./.env:/var/www/html/.env:ro
     networks:
       - web
       - teal-internal
@@ -122,10 +123,7 @@ services:
   # Queue Worker: Processes background jobs (metadata enrichment, imports)
   # --------------------------------------------------------------------------
   queue:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
+    image: ${TEAL_IMAGE:-ghcr.io/dotmavriq/teal}:${TEAL_TAG:-latest}
     container_name: teal-queue
     restart: unless-stopped
     depends_on:

--- a/docker/deploy-prod.sh
+++ b/docker/deploy-prod.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# =============================================================================
+# TEAL Production Pull-Deploy (runs ON gerty)
+# =============================================================================
+# Invoked by CI over SSH after the image is built + pushed to GHCR:
+#   TEAL_TAG=<commit-sha> ./docker/deploy-prod.sh
+#
+# DATA SAFETY IS THE PRIME DIRECTIVE. This script:
+#   - acts on the `app` and `queue` services ONLY, by explicit name
+#   - NEVER runs: down / down -v / volume rm / --renew-anon-volumes
+#   - NEVER touches the `db` service or the teal-db-data volume
+#   - takes + verifies a DB backup before anything goes live (no backup = abort)
+#   - HALTS if a pending migration looks destructive (DROP/TRUNCATE/DELETE)
+#   - rolls back to the previous image if the new app fails its health check
+# =============================================================================
+set -euo pipefail
+
+# ---- Config ----
+PROJECT_DIR="${PROJECT_DIR:-/opt/teal/app}"
+BACKUP_DIR="${BACKUP_DIR:-/opt/teal/backups}"
+TEAL_IMAGE="${TEAL_IMAGE:-ghcr.io/dotmavriq/teal}"
+TEAL_TAG="${TEAL_TAG:?TEAL_TAG (commit sha) must be set}"
+KEEP_BACKUPS="${KEEP_BACKUPS:-10}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-120}"
+COMPOSE="docker compose"
+
+export TEAL_IMAGE TEAL_TAG
+IMAGE_REF="${TEAL_IMAGE}:${TEAL_TAG}"
+
+log()   { echo "[deploy-prod] $(date '+%H:%M:%S') $*"; }
+warn()  { echo "[deploy-prod] $(date '+%H:%M:%S') WARN: $*" >&2; }
+fatal() { echo "[deploy-prod] $(date '+%H:%M:%S') FATAL: $*" >&2; exit 1; }
+
+cd "$PROJECT_DIR" || fatal "Project dir $PROJECT_DIR not found"
+
+# ---- 0. Guard: never let this script be used to tear down data ----
+case " $* " in
+    *" down "*|*" -v "*|*"volume"*) fatal "Refusing: destructive arg passed to deploy script" ;;
+esac
+
+# ---- 1. Pre-flight ----
+log "Pre-flight checks (image: $IMAGE_REF)..."
+[ -f .env ]            || fatal ".env missing in $PROJECT_DIR"
+[ -f .env.production ] || fatal ".env.production missing in $PROJECT_DIR"
+docker network inspect web >/dev/null 2>&1 || fatal "Docker network 'web' missing"
+
+db_health="$(docker inspect --format '{{.State.Health.Status}}' teal-db 2>/dev/null || echo missing)"
+[ "$db_health" = "healthy" ] || fatal "teal-db is not healthy (status: $db_health) — aborting before touching anything"
+log "  teal-db: healthy"
+
+# Capture the currently-running image so we can roll back to it.
+PREV_IMAGE="$(docker inspect --format '{{.Config.Image}}' teal-app 2>/dev/null || echo '')"
+log "  current app image: ${PREV_IMAGE:-<none>}"
+
+# ---- 2. Backup the database (NO BACKUP = NO DEPLOY) ----
+log "Backing up production database..."
+mkdir -p "$BACKUP_DIR"
+TS="$(date +%Y%m%d-%H%M%S)"
+BACKUP_FILE="$BACKUP_DIR/teal-${TS}.sql.gz"
+
+if ! docker exec teal-db pg_dump -U teal teal | gzip > "$BACKUP_FILE"; then
+    rm -f "$BACKUP_FILE"
+    fatal "pg_dump failed — aborting deploy, prod left untouched"
+fi
+gzip -t "$BACKUP_FILE" 2>/dev/null || { rm -f "$BACKUP_FILE"; fatal "Backup failed gzip integrity check"; }
+# Sanity: dump must contain the key tables, not an empty/error dump.
+if ! gunzip -c "$BACKUP_FILE" | grep -q 'CREATE TABLE public.books'; then
+    rm -f "$BACKUP_FILE"
+    fatal "Backup missing expected tables — aborting deploy"
+fi
+log "  backup OK: $BACKUP_FILE ($(du -h "$BACKUP_FILE" | cut -f1))"
+
+# Rotate: keep the most recent $KEEP_BACKUPS.
+ls -t "$BACKUP_DIR"/teal-*.sql.gz 2>/dev/null | tail -n +"$((KEEP_BACKUPS + 1))" | xargs -r rm -f
+log "  backups retained: $(ls "$BACKUP_DIR"/teal-*.sql.gz 2>/dev/null | wc -l)"
+
+# ---- 3. Pull the new image (app + queue share it) ----
+log "Pulling new image..."
+$COMPOSE pull app queue
+
+# ---- 4. Destructive-migration guard ----
+# Render the SQL of pending migrations WITHOUT executing it, then scan for
+# data-destroying statements. Schema-only drops (index/constraint) are allowed.
+log "Scanning pending migrations for destructive statements..."
+PRETEND_SQL="$(docker run --rm \
+    --network teal-internal \
+    -e DB_HOST=db -e DB_PORT=5432 -e APP_ENV=production \
+    -v "$PROJECT_DIR/.env:/var/www/html/.env:ro" \
+    --entrypoint php "$IMAGE_REF" \
+    artisan migrate --pretend --no-ansi 2>&1)" || {
+        warn "migrate --pretend could not run cleanly; output was:"
+        echo "$PRETEND_SQL" >&2
+        fatal "Could not verify migration safety — aborting before going live"
+    }
+
+if echo "$PRETEND_SQL" | grep -iqE 'drop table|drop column|truncate|delete from|alter table .*drop '; then
+    echo "$PRETEND_SQL" >&2
+    fatal "DESTRUCTIVE migration detected in pending changes — HALTING. Backup is at $BACKUP_FILE. Run it manually & deliberately if intended."
+fi
+log "  no destructive migrations pending (additive changes will auto-apply)"
+
+# ---- 5. Go live: recreate ONLY app + queue ----
+log "Recreating app + queue with $IMAGE_REF (db untouched)..."
+$COMPOSE up -d --no-deps app queue
+
+# ---- 6. Health gate (rollback on failure) ----
+log "Waiting for teal-app to become healthy (timeout ${HEALTH_TIMEOUT}s)..."
+elapsed=0
+while [ "$elapsed" -lt "$HEALTH_TIMEOUT" ]; do
+    status="$(docker inspect --format '{{.State.Health.Status}}' teal-app 2>/dev/null || echo missing)"
+    if [ "$status" = "healthy" ]; then
+        log "=== Deploy OK — teal-app healthy on $IMAGE_REF ==="
+        docker image prune -f >/dev/null 2>&1 || true
+        exit 0
+    fi
+    [ "$status" = "unhealthy" ] && break
+    sleep 4; elapsed=$((elapsed + 4))
+done
+
+warn "teal-app did not become healthy (last status: ${status:-unknown})"
+if echo "$PREV_IMAGE" | grep -q "^${TEAL_IMAGE}:"; then
+    PREV_TAG="${PREV_IMAGE##*:}"
+    warn "Rolling back to previous image: $PREV_IMAGE"
+    TEAL_TAG="$PREV_TAG" $COMPOSE up -d --no-deps app queue
+    fatal "Deploy failed health check — rolled back to $PREV_IMAGE. DB untouched; backup at $BACKUP_FILE"
+else
+    fatal "Deploy failed health check and no GHCR previous image to auto-roll-back to (was: ${PREV_IMAGE:-none}). DB untouched; backup at $BACKUP_FILE. Investigate manually."
+fi


### PR DESCRIPTION
## What

Continuous deployment to **teal.dotmavriq.life** on every push to `main`, gated on the existing `quality` + `tests` jobs. Image is built in CI and **pulled** on gerty (gerty's 1-core/2 GB box never builds).

## Flow
```
push main → quality + tests green → build image → push ghcr.io/dotmavriq/teal:<sha>
          → ssh gerty → backup DB → migrate-guard → pull → restart app+queue → health-gate
```

## 🛡️ Data protection (prime directive)
The prod Postgres data lives in the named volume `teal-db-data`, separate from the app image. `docker/deploy-prod.sh`:
- acts on **`app` + `queue` only**, by explicit name — **never** touches the `db` service or its volume
- **forbidden**: `down`, `down -v`, `volume rm`, `--renew-anon-volumes`
- **no backup = no deploy**: a verified (`gzip -t` + table-presence) `pg_dump` runs *before* anything goes live; rotates last 10
- **destructive-migration guard**: renders pending migration SQL via `migrate --pretend` and **HALTS** on `DROP TABLE/COLUMN`, `TRUNCATE`, `DELETE FROM` (additive migrations auto-apply)
- **health-gated**: rolls back to the previous image if the new `teal-app` fails its health check

## Secrets
`.env` / `.env.production` stay **only on gerty** (the image carries no secrets). CI needs repo secrets `GERTY_HOST`, `GERTY_USER`, `GERTY_SSH_KEY` (set out-of-band) and the built-in `GITHUB_TOKEN` for GHCR.

## Notes
- The `app`/`queue` `build:` blocks become `image:`. Local/dev builds use `docker-compose.dev.yml`.
- First merge to main triggers the first deploy (ships the current main; ~65 commits ahead of what's live). Will be babysat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced production deployment automation with safety checks including pre-deployment validation, automatic backups, and rollback capabilities.
  * Updated deployment infrastructure to use pre-built container images for faster, more consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->