### PR TITLE
style: apply Rector to read-queue files (green the advisory job)

### DIFF
--- a/app/Livewire/Books/BookIndex.php
+++ b/app/Livewire/Books/BookIndex.php
@@ -95,7 +95,7 @@ class BookIndex extends Component
         if ($status === 'read' && $book->queue_position !== null) {
             $oldPosition = $book->queue_position;
 
-            Book::withoutTimestamps(function () use ($book, $oldPosition) {
+            Book::withoutTimestamps(function () use ($book, $oldPosition): void {
                 $book->update(['queue_position' => null]);
 
                 Book::where('user_id', Auth::id())

--- a/app/Livewire/Books/BookShow.php
+++ b/app/Livewire/Books/BookShow.php
@@ -74,7 +74,7 @@ class BookShow extends Component
 
         // Reordering the queue must not touch updated_at, or every shifted book
         // would jump to the top of the "Recently Updated" sort on /books.
-        Book::withoutTimestamps(function () use ($oldPosition) {
+        Book::withoutTimestamps(function () use ($oldPosition): void {
             $this->book->update(['queue_position' => null]);
 
             if ($oldPosition !== null) {

--- a/app/Livewire/Books/ReadQueue.php
+++ b/app/Livewire/Books/ReadQueue.php
@@ -39,7 +39,7 @@ class ReadQueue extends Component
 
         // Reordering must not touch updated_at, or shifted books jump to the
         // top of the "Recently Updated" sort on /books.
-        Book::withoutTimestamps(function () use ($book, $oldPosition) {
+        Book::withoutTimestamps(function () use ($book, $oldPosition): void {
             $book->update(['queue_position' => null]);
 
             if ($oldPosition !== null) {
@@ -63,7 +63,7 @@ class ReadQueue extends Component
             ->first();
 
         if ($swapWith) {
-            Book::withoutTimestamps(function () use ($book, $swapWith) {
+            Book::withoutTimestamps(function () use ($book, $swapWith): void {
                 $swapWith->update(['queue_position' => $book->queue_position]);
                 $book->update(['queue_position' => $book->queue_position - 1]);
             });
@@ -83,7 +83,7 @@ class ReadQueue extends Component
             ->first();
 
         if ($swapWith) {
-            Book::withoutTimestamps(function () use ($book, $swapWith) {
+            Book::withoutTimestamps(function () use ($book, $swapWith): void {
                 $swapWith->update(['queue_position' => $book->queue_position]);
                 $book->update(['queue_position' => $book->queue_position + 1]);
             });
@@ -98,7 +98,7 @@ class ReadQueue extends Component
             return;
         }
 
-        Book::withoutTimestamps(function () use ($book) {
+        Book::withoutTimestamps(function () use ($book): void {
             // Shift all items above down by 1
             Book::where('user_id', Auth::id())
                 ->where('queue_position', '<', $book->queue_position)
@@ -124,7 +124,7 @@ class ReadQueue extends Component
             return;
         }
 
-        Book::withoutTimestamps(function () use ($book, $maxPosition) {
+        Book::withoutTimestamps(function () use ($book, $maxPosition): void {
             // Shift all items below up by 1
             Book::where('user_id', Auth::id())
                 ->where('queue_position', '>', $book->queue_position)

--- a/tests/Feature/BookQueueTimestampTest.php
+++ b/tests/Feature/BookQueueTimestampTest.php
@@ -7,9 +7,11 @@ use App\Livewire\Books\BookIndex;
 use App\Livewire\Books\ReadQueue;
 use App\Models\Book;
 use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
 use Livewire\Livewire;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->user = User::factory()->create();
 });
 
@@ -17,7 +19,7 @@ beforeEach(function () {
  * Create `count` queued books (positions 1..count) whose updated_at is
  * backdated to a known point, so we can detect any spurious "touch".
  */
-function queuedBooks(User $user, int $count, Carbon\Carbon $backdatedTo): Illuminate\Support\Collection
+function queuedBooks(User $user, int $count, Carbon $backdatedTo): Collection
 {
     $books = collect(range(1, $count))->map(fn (int $position) => Book::factory()->wantToRead()->create([
         'user_id' => $user->id,
@@ -30,7 +32,7 @@ function queuedBooks(User $user, int $count, Carbon\Carbon $backdatedTo): Illumi
     return $books->each->refresh();
 }
 
-it('does not bump other queued books updated_at when one is marked read', function () {
+it('does not bump other queued books updated_at when one is marked read', function (): void {
     $past = now()->subDays(10);
     [$first, $second, $third] = queuedBooks($this->user, 3, $past)->all();
 
@@ -57,7 +59,7 @@ it('does not bump other queued books updated_at when one is marked read', functi
         ->and($first->updated_at->timestamp)->toBeGreaterThan($past->timestamp);
 });
 
-it('does not bump other queued books updated_at when one is removed from the queue', function () {
+it('does not bump other queued books updated_at when one is removed from the queue', function (): void {
     $past = now()->subDays(10);
     [$first, $second, $third] = queuedBooks($this->user, 3, $past)->all();
 
@@ -74,7 +76,7 @@ it('does not bump other queued books updated_at when one is removed from the que
         ->and($third->updated_at->format('Y-m-d H:i:s'))->toBe($past->format('Y-m-d H:i:s'));
 });
 
-it('does not bump updated_at when reordering the queue', function () {
+it('does not bump updated_at when reordering the queue', function (): void {
     $past = now()->subDays(10);
     [$first, $second, $third] = queuedBooks($this->user, 3, $past)->all();
 


### PR DESCRIPTION
Adds the closure `: void` return types Rector flags on the cherry-picked read-queue files (#49 predated the Rector ruleset). No behavior change — Rector/PHPStan/Pint all clean, full test suite assertions intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)