### PR TITLE
feat(theme): ship Teal 2026 as the default theme

### DIFF
--- a/app/Livewire/ThemeSwitcher.php
+++ b/app/Livewire/ThemeSwitcher.php
@@ -24,8 +24,8 @@ class ThemeSwitcher extends Component
             return;
         }
 
-        $default = config('themes.default', 'normie');
-        $this->theme = is_string($default) ? $default : 'normie';
+        $default = config('themes.default', 'teal-2026');
+        $this->theme = is_string($default) ? $default : 'teal-2026';
     }
 
     public function setTheme(string $theme): void

--- a/config/themes.php
+++ b/config/themes.php
@@ -20,6 +20,11 @@ return [
 
     'available' => [
         [
+            'name' => 'Teal 2026',
+            'value' => 'teal-2026',
+            'description' => 'The brand theme — cream, teal and coral',
+        ],
+        [
             'name' => 'Normie',
             'value' => 'normie',
             'description' => 'Clean light theme',
@@ -31,5 +36,5 @@ return [
         ],
     ],
 
-    'default' => 'normie',
+    'default' => 'teal-2026',
 ];

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -572,6 +572,13 @@ input[type="search"]::-webkit-search-results-decoration {
         border-bottom: 3px solid rgb(31 50 49) !important;
     }
 
+    /* Page header: a clean full-width ink bar, not an offset shadow */
+    header {
+        --tw-shadow: 0 0 #0000 !important;
+        --tw-shadow-colored: 0 0 #0000 !important;
+        border-bottom: 3px solid rgb(31 50 49) !important;
+    }
+
     /* Breadcrumbs: an ink-pill trail instead of muted grey */
     nav[aria-label="Breadcrumb"] ol { gap: 0.5rem; }
     nav[aria-label="Breadcrumb"] li { color: rgb(31 50 49); font-weight: 700; }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -567,8 +567,29 @@ input[type="search"]::-webkit-search-results-decoration {
         transform: translate(2px, 2px);
     }
 
-    /* Top bar: bold ink underline */
-    nav {
+    /* Top bar (the bordered one only): bold ink underline */
+    nav.border-b {
         border-bottom: 3px solid rgb(31 50 49) !important;
+    }
+
+    /* Breadcrumbs: an ink-pill trail instead of muted grey */
+    nav[aria-label="Breadcrumb"] ol { gap: 0.5rem; }
+    nav[aria-label="Breadcrumb"] li { color: rgb(31 50 49); font-weight: 700; }
+    nav[aria-label="Breadcrumb"] li:first-child a {
+        display: inline-flex; align-items: center; padding: 5px;
+        background: #fff; color: rgb(31 50 49);
+        border: 2px solid rgb(31 50 49); border-radius: 7px;
+        box-shadow: 2px 2px 0 rgb(31 50 49);
+        transition: transform 0.08s ease, box-shadow 0.08s ease;
+    }
+    nav[aria-label="Breadcrumb"] li:first-child a:hover {
+        background: #7FE3E6;
+        transform: translate(-1px, -1px); box-shadow: 3px 3px 0 rgb(31 50 49);
+    }
+    nav[aria-label="Breadcrumb"] li:last-child span {
+        display: inline-block; padding: 3px 12px;
+        background: #fff; color: rgb(31 50 49);
+        border: 2px solid rgb(31 50 49); border-radius: 999px;
+        box-shadow: 2px 2px 0 rgb(31 50 49); font-weight: 700;
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -544,3 +544,31 @@ input[type="search"]::-webkit-search-results-decoration {
         --tw-shadow-color: rgba(0, 0, 0, 0.4);
     }
 }
+
+/* ============================================
+   Teal 2026 — subtle 2026 neubrutalism
+   (scoped to this theme ONLY; others unaffected)
+   ============================================ */
+[data-theme="teal-2026"] {
+    /* Hard offset ink shadows, layered over any existing ring */
+    .shadow-sm { --tw-shadow: 3px 3px 0 rgb(31 50 49 / 0.85); --tw-shadow-colored: 3px 3px 0 var(--tw-shadow-color); }
+    .shadow, .shadow-md { --tw-shadow: 4px 4px 0 rgb(31 50 49 / 0.9); --tw-shadow-colored: 4px 4px 0 var(--tw-shadow-color); }
+    .shadow-lg, .shadow-xl { --tw-shadow: 6px 6px 0 rgb(31 50 49 / 0.95); --tw-shadow-colored: 6px 6px 0 var(--tw-shadow-color); }
+
+    /* Crisp ink outline on ringed surfaces (cards, chips) */
+    .ring-1 { --tw-ring-color: rgb(31 50 49); }
+
+    /* Buttons: ink edge + tactile press */
+    .btn-primary, .btn-secondary, .btn-danger {
+        border: 2px solid rgb(31 50 49);
+        transition: transform 0.08s ease, box-shadow 0.08s ease;
+    }
+    .btn-primary:active, .btn-secondary:active, .btn-danger:active {
+        transform: translate(2px, 2px);
+    }
+
+    /* Top bar: bold ink underline */
+    nav {
+        border-bottom: 3px solid rgb(31 50 49) !important;
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -13,8 +13,147 @@
    ============================================ */
 
 @layer base {
-    /* Default/Normie Theme (Light) */
+    /* ===== Default — Teal 2026 (brand) ===== */
     :root,
+    [data-theme="teal-2026"] {
+        /* Backgrounds: top bar = favicon light-teal, page = cream, cards = white */
+        --color-bg-primary: 127 227 230;      /* light-teal #7FE3E6 (top bar / headers) */
+        --color-bg-secondary: 250 247 238;    /* cream #FAF7EE (page) */
+        --color-bg-tertiary: 235 251 251;     /* very light teal #EBFBFB */
+        --color-bg-hover: 224 246 246;        /* light teal hover */
+        --color-bg-active: 198 238 239;       /* teal-tinted active */
+
+        /* Text */
+        --color-text-primary: 31 50 49;       /* ink #1F3231 */
+        --color-text-secondary: 60 84 82;
+        --color-text-tertiary: 94 116 114;
+        --color-text-muted: 130 152 150;
+        --color-text-inverted: 255 255 255;
+
+        /* Borders */
+        --color-border-primary: 209 230 228;  /* soft teal-gray */
+        --color-border-secondary: 178 208 205;
+        --color-border-focus: 0 175 180;      /* teal #00AFB4 */
+
+        /* Buttons */
+        --color-btn-primary-bg: 0 175 180;    /* teal */
+        --color-btn-primary-hover: 11 143 148;
+        --color-btn-primary-text: 255 255 255;
+        --color-btn-secondary-bg: 255 255 255;
+        --color-btn-secondary-hover: 250 247 238;
+        --color-btn-secondary-text: 31 50 49;
+        --color-btn-secondary-border: 31 50 49; /* ink */
+        --color-btn-danger-bg: 232 81 63;     /* coral-700 #E8513F */
+        --color-btn-danger-hover: 200 60 45;
+        --color-btn-danger-text: 255 255 255;
+
+        /* Accents */
+        --color-accent-primary: 0 175 180;    /* teal */
+        --color-accent-primary-hover: 11 143 148;
+        --color-accent-secondary: 255 107 92; /* coral #FF6B5C */
+
+        /* Status Colors */
+        --color-success: 34 197 94;
+        --color-success-bg: 240 253 244;
+        --color-success-text: 21 128 61;
+        --color-warning: 245 158 11;
+        --color-warning-bg: 255 251 235;
+        --color-warning-text: 180 83 9;
+        --color-danger: 232 81 63;            /* coral-red */
+        --color-danger-bg: 255 241 238;
+        --color-danger-text: 200 50 35;
+        --color-info: 0 175 180;              /* teal */
+        --color-info-bg: 235 251 251;
+        --color-info-text: 11 143 148;
+
+        /* Reading Status */
+        --color-status-want: 0 175 180;       /* teal */
+        --color-status-want-bg: 235 251 251;
+        --color-status-reading: 245 158 11;
+        --color-status-reading-bg: 255 251 235;
+        --color-status-read: 34 197 94;
+        --color-status-read-bg: 240 253 244;
+
+        /* Watching Status */
+        --color-status-watchlist: 147 51 234;
+        --color-status-watchlist-bg: 250 245 255;
+        --color-status-watching: 245 158 11;
+        --color-status-watching-bg: 255 251 235;
+        --color-status-watched: 34 197 94;
+        --color-status-watched-bg: 240 253 244;
+
+        /* Playing statuses */
+        --color-status-backlog: 107 114 128;
+        --color-status-backlog-bg: 243 244 246;
+        --color-status-playing: 245 158 11;
+        --color-status-playing-bg: 255 251 235;
+        --color-status-shelved: 234 88 12;
+        --color-status-shelved-bg: 255 247 237;
+        --color-status-completed: 34 197 94;
+        --color-status-completed-bg: 240 253 244;
+        --color-status-mastered: 147 51 234;
+        --color-status-mastered-bg: 250 245 255;
+
+        /* Board Game statuses */
+        --color-status-owned: 34 197 94;
+        --color-status-owned-bg: 240 253 244;
+        --color-status-want-to-play: 0 175 180;
+        --color-status-want-to-play-bg: 235 251 251;
+        --color-status-wishlist: 245 158 11;
+        --color-status-wishlist-bg: 255 251 235;
+        --color-status-for-trade: 234 88 12;
+        --color-status-for-trade-bg: 255 247 237;
+        --color-status-previously-owned: 107 114 128;
+        --color-status-previously-owned-bg: 243 244 246;
+
+        /* Platform Colors (brand logos, kept functional) */
+        --color-platform-nintendo: 229 36 39;
+        --color-platform-nintendo-bg: 254 242 242;
+        --color-platform-nintendo-logo: 255 255 255;
+        --color-platform-steam: 27 40 56;
+        --color-platform-steam-bg: 239 246 255;
+        --color-platform-steam-logo: 255 255 255;
+        --color-platform-playstation: 0 55 145;
+        --color-platform-playstation-bg: 239 246 255;
+        --color-platform-playstation-logo: 255 255 255;
+        --color-platform-xbox: 16 124 16;
+        --color-platform-xbox-bg: 240 253 244;
+        --color-platform-xbox-logo: 255 255 255;
+        --color-platform-gog: 164 93 226;
+        --color-platform-gog-bg: 250 245 255;
+        --color-platform-gog-logo: 255 255 255;
+        --color-platform-pc: 75 85 99;
+        --color-platform-pc-bg: 243 244 246;
+        --color-platform-pc-logo: 255 255 255;
+        --color-platform-default: 107 114 128;
+        --color-platform-default-bg: 243 244 246;
+        --color-platform-default-logo: 255 255 255;
+
+        /* Stars */
+        --color-star-filled: 255 210 63;      /* brand yellow #FFD23F */
+        --color-star-empty: 200 225 224;      /* teal-gray */
+
+        /* Shadows */
+        --color-shadow: 0 0 0;
+        --shadow-opacity: 0.1;
+
+        /* Inputs */
+        --color-input-bg: 255 255 255;
+        --color-input-text: 31 50 49;
+        --color-input-border: 178 208 205;
+        --color-input-focus-ring: 0 175 180;
+        --color-input-placeholder: 130 152 150;
+
+        /* Cards */
+        --color-card-bg: 255 255 255;
+        --color-card-border: 209 230 228;
+
+        /* Links */
+        --color-link: 0 175 180;
+        --color-link-hover: 11 143 148;
+    }
+
+    /* Normie Theme (Light) */
     [data-theme="normie"] {
         /* Backgrounds */
         --color-bg-primary: 255 255 255;      /* white */
@@ -343,7 +482,8 @@
         background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%23928374' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
     }
 
-    [data-theme="normie"] select {
+    [data-theme="normie"] select,
+    [data-theme="teal-2026"] select {
         background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
     }
 }

--- a/resources/views/components/application-logo.blade.php
+++ b/resources/views/components/application-logo.blade.php
@@ -1,1 +1,1 @@
-<img src="{{ asset('android-chrome-192x192.png') }}" alt="TEAL" {{ $attributes->merge(['class' => 'h-9 w-9']) }}>
+<img src="{{ asset('brand/seal-glyph.svg') }}" alt="TEAL" {{ $attributes->merge(['class' => 'h-9 w-auto']) }}>

--- a/resources/views/components/application-logo.blade.php
+++ b/resources/views/components/application-logo.blade.php
@@ -1,1 +1,1 @@
-<img src="{{ asset('brand/seal-glyph.svg') }}" alt="TEAL" {{ $attributes->merge(['class' => 'h-9 w-auto']) }}>
+<img src="{{ asset('brand/seal-glyph.svg') }}" alt="TEAL" {{ $attributes->merge(['class' => 'w-auto']) }}>

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-theme="{{ auth()->user()?->theme ?? config('themes.default', 'normie') }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-theme="{{ auth()->user()?->theme ?? config('themes.default', 'teal-2026') }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -8,17 +8,17 @@
         <title>{{ config('app.name', 'TEAL') }}</title>
 
         <!-- Theme meta tag for JavaScript access -->
-        <meta name="user-theme" content="{{ auth()->user()?->theme ?? config('themes.default', 'normie') }}">
+        <meta name="user-theme" content="{{ auth()->user()?->theme ?? config('themes.default', 'teal-2026') }}">
 
         <!-- Theme must be set BEFORE CSS loads to prevent flash -->
         <script>
             (function() {
                 var storedTheme = localStorage.getItem('teal-theme');
                 var metaTheme = document.querySelector('meta[name="user-theme"]')?.content;
-                var theme = storedTheme || metaTheme || 'normie';
+                var theme = storedTheme || metaTheme || 'teal-2026';
                 document.documentElement.setAttribute('data-theme', theme);
                 // Sync localStorage with server theme if empty
-                if (!storedTheme && metaTheme && metaTheme !== 'normie') {
+                if (!storedTheme && metaTheme && metaTheme !== 'teal-2026') {
                     localStorage.setItem('teal-theme', metaTheme);
                 }
             })();
@@ -34,11 +34,11 @@
         <!-- Ensure theme persists across Livewire navigations -->
         <script>
             (function() {
-                var serverTheme = '{{ auth()->user()?->theme ?? config('themes.default', 'normie') }}';
+                var serverTheme = '{{ auth()->user()?->theme ?? config('themes.default', 'teal-2026') }}';
                 var storedTheme = localStorage.getItem('teal-theme');
                 var userTheme = storedTheme || serverTheme;
 
-                if (serverTheme !== 'normie' && serverTheme !== storedTheme) {
+                if (serverTheme !== 'teal-2026' && serverTheme !== storedTheme) {
                     localStorage.setItem('teal-theme', serverTheme);
                     userTheme = serverTheme;
                 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-theme="{{ auth()->user()?->theme ?? config('themes.default', 'normie') }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-theme="{{ auth()->user()?->theme ?? config('themes.default', 'teal-2026') }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -8,17 +8,17 @@
         <title>{{ config('app.name', 'TEAL') }}</title>
 
         <!-- Theme meta tag for JavaScript access -->
-        <meta name="user-theme" content="{{ auth()->user()?->theme ?? config('themes.default', 'normie') }}">
+        <meta name="user-theme" content="{{ auth()->user()?->theme ?? config('themes.default', 'teal-2026') }}">
 
         <!-- Theme must be set BEFORE CSS loads to prevent flash -->
         <script>
             (function() {
                 var storedTheme = localStorage.getItem('teal-theme');
                 var metaTheme = document.querySelector('meta[name="user-theme"]')?.content;
-                var theme = storedTheme || metaTheme || 'normie';
+                var theme = storedTheme || metaTheme || 'teal-2026';
                 document.documentElement.setAttribute('data-theme', theme);
                 // Sync localStorage with server theme if empty
-                if (!storedTheme && metaTheme && metaTheme !== 'normie') {
+                if (!storedTheme && metaTheme && metaTheme !== 'teal-2026') {
                     localStorage.setItem('teal-theme', metaTheme);
                 }
             })();
@@ -35,22 +35,21 @@
         <meta property="og:url" content="{{ url()->current() }}">
         <meta property="og:title" content="TEAL | The Essential Aggregator Library">
         <meta property="og:description" content="Self-hosted personal media tracker. Track films, TV, books, anime, comics, games, board games, and music with API-powered search, imports, and gallery views.">
-        <meta property="og:image" content="{{ asset('android-chrome-512x512.png') }}">
+        <meta property="og:image" content="{{ asset('brand/og.png') }}">
 
         <!-- Twitter -->
         <meta name="twitter:card" content="summary">
         <meta name="twitter:title" content="TEAL | The Essential Aggregator Library">
         <meta name="twitter:description" content="Self-hosted personal media tracker. Track films, TV, books, anime, comics, games, board games, and music with API-powered search, imports, and gallery views.">
-        <meta name="twitter:image" content="{{ asset('android-chrome-512x512.png') }}">
+        <meta name="twitter:image" content="{{ asset('brand/og.png') }}">
 
         <!-- Favicon -->
-        <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('apple-touch-icon.png') }}">
-        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicon-32x32.png') }}">
-        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicon-16x16.png') }}">
-        <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}">
+        <link rel="icon" href="{{ asset('favicon.ico') }}" sizes="any">
+        <link rel="icon" href="{{ asset('favicon.svg') }}" type="image/svg+xml">
+        <link rel="apple-touch-icon" href="{{ asset('apple-touch-icon.png') }}">
         <link rel="manifest" href="{{ asset('site.webmanifest') }}">
-        <meta name="theme-color" content="#1e40af">
-        <meta name="msapplication-TileColor" content="#1e40af">
+        <meta name="theme-color" content="#7FE3E6">
+        <meta name="msapplication-TileColor" content="#7FE3E6">
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
@@ -64,13 +63,13 @@
         <!-- Ensure theme is applied immediately and persists across Livewire navigations -->
         <script>
             (function() {
-                var serverTheme = '{{ auth()->user()?->theme ?? config('themes.default', 'normie') }}';
+                var serverTheme = '{{ auth()->user()?->theme ?? config('themes.default', 'teal-2026') }}';
                 // Check localStorage first (updated by ThemeSwitcher), fallback to server value
                 var storedTheme = localStorage.getItem('teal-theme');
                 var userTheme = storedTheme || serverTheme;
 
                 // Update localStorage with server value if it differs (user might have changed it elsewhere)
-                if (serverTheme !== 'normie' && serverTheme !== storedTheme) {
+                if (serverTheme !== 'teal-2026' && serverTheme !== storedTheme) {
                     localStorage.setItem('teal-theme', serverTheme);
                     userTheme = serverTheme;
                 }

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -1,58 +1,35 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-theme="{{ auth()->user()?->theme ?? config('themes.default', 'normie') }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-theme="{{ auth()->user()?->theme ?? config('themes.default', 'teal-2026') }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title>{{ config('app.name', 'TEAL') }}</title>
-
-        <!-- SEO Meta Tags -->
-        <meta name="description" content="TEAL - The Essential Aggregator Library. A self-hosted media tracker for films, TV, books, anime, comics, games, board games, and music.">
-        <meta name="keywords" content="media tracker, self-hosted, films, books, anime, comics, games, board games, albums, library">
-        <meta name="author" content="TEAL">
-        <meta name="robots" content="index, follow">
-
-        <!-- Open Graph / Facebook -->
-        <meta property="og:type" content="website">
-        <meta property="og:url" content="{{ url()->current() }}">
-        <meta property="og:title" content="TEAL | The Essential Aggregator Library">
-        <meta property="og:description" content="Self-hosted personal media tracker. Track films, TV, books, anime, comics, games, board games, and music with API-powered search, imports, and gallery views.">
-        <meta property="og:image" content="{{ asset('android-chrome-512x512.png') }}">
-
-        <!-- Twitter -->
-        <meta name="twitter:card" content="summary">
-        <meta name="twitter:title" content="TEAL | The Essential Aggregator Library">
-        <meta name="twitter:description" content="Self-hosted personal media tracker. Track films, TV, books, anime, comics, games, board games, and music with API-powered search, imports, and gallery views.">
-        <meta name="twitter:image" content="{{ asset('android-chrome-512x512.png') }}">
+        <meta name="description" content="TEAL — a self-hosted tracker for everything you read, watch, play and listen to.">
 
         <!-- Favicon -->
-        <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('apple-touch-icon.png') }}">
-        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicon-32x32.png') }}">
-        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicon-16x16.png') }}">
-        <link rel="icon" type="image/x-icon" href="{{ asset('favicon.ico') }}">
+        <link rel="icon" href="{{ asset('favicon.ico') }}" sizes="any">
+        <link rel="icon" href="{{ asset('favicon.svg') }}" type="image/svg+xml">
+        <link rel="apple-touch-icon" href="{{ asset('apple-touch-icon.png') }}">
         <link rel="manifest" href="{{ asset('site.webmanifest') }}">
-        <meta name="theme-color" content="#1e40af">
-        <meta name="msapplication-TileColor" content="#1e40af">
+        <meta name="theme-color" content="#7FE3E6">
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
-        <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
-
         @livewireStyles
     </head>
-    <body class="font-sans antialiased bg-theme-bg-secondary text-theme-text-primary">
-        <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0">
-            <div>
-                <a href="/" wire:navigate>
-                    <x-application-logo class="w-20 h-20 fill-current text-theme-text-secondary" />
-                </a>
-            </div>
+    <body class="font-sans antialiased bg-theme-bg-primary text-theme-text-primary">
+        <div class="min-h-screen flex flex-col justify-center items-center px-6 py-10">
+            <a href="/" wire:navigate class="mb-8">
+                <img src="{{ asset('brand/seal-hero.svg') }}" alt="TEAL"
+                     class="h-44 w-auto" style="filter: drop-shadow(4px 5px 0 rgba(31,50,49,.16));">
+            </a>
 
-            <div class="w-full sm:max-w-md mt-6 px-6 py-4 bg-theme-card-bg shadow-md overflow-hidden sm:rounded-lg">
+            <div class="w-full sm:max-w-md px-7 py-7 bg-theme-card-bg border-2 border-theme-text-primary rounded-xl shadow-lg">
                 {{ $slot }}
             </div>
         </div>

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -24,7 +24,7 @@ new class extends Component
                 <!-- Logo -->
                 <div class="shrink-0 flex items-center">
                     <a href="{{ route('dashboard') }}" wire:navigate>
-                        <x-application-logo class="block h-[4.5rem] w-auto -my-3" />
+                        <x-application-logo class="block h-16 w-auto" />
                     </a>
                 </div>
 

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -24,7 +24,7 @@ new class extends Component
                 <!-- Logo -->
                 <div class="shrink-0 flex items-center">
                     <a href="{{ route('dashboard') }}" wire:navigate>
-                        <x-application-logo class="block h-14 w-auto" />
+                        <x-application-logo class="block h-[4.5rem] w-auto -my-3" />
                     </a>
                 </div>
 

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -24,7 +24,7 @@ new class extends Component
                 <!-- Logo -->
                 <div class="shrink-0 flex items-center">
                     <a href="{{ route('dashboard') }}" wire:navigate>
-                        <x-application-logo class="block h-9 w-auto fill-current text-theme-text-primary" />
+                        <x-application-logo class="block h-14 w-auto" />
                     </a>
                 </div>
 


### PR DESCRIPTION
## What
Brings the **Teal 2026** neubrutalist brand theme to production. The 5 theme commits from `feat/teal-2026-theme` rebased onto current main (40 commits of drift).

- `config/themes.php`: Teal 2026 is now the default theme
- `resources/css/app.css`: +183 lines of the 2026 look (neubrutalist accents, nav, breadcrumb, header bar)
- layout/nav/logo blade refinements

## Conflict resolution
Only one conflict — `ThemeSwitcher.php`, where main's Rector pass had added type guards while the branch simplified `mount()`. Kept main's PHPStan-clean structure and adopted the branch's intent (default fallback `teal-2026`).

## Verification
- Pint / PHPStan (level max) / Rector → all clean
- `npm run build` → compiles (app.css 75 KB)
- Test suite assertions intact

Merges → auto-deploys to teal.dotmavriq.life via the live pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)