### PR TITLE
ci(review-bots): on-demand, non-redundant Qodo + CodeRabbit split

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,18 +1,57 @@
-# CodeRabbit Configuration for TEAL
+# ─────────────────────────────────────────────────────────────────────────────
+# CodeRabbit — TEAL code-review policy
+#
+# ROLE: Presentation-layer & comprehension specialist.
+#   CodeRabbit reviews the rendered surface (Blade / CSS / assets) for Core Web
+#   Vitals, accessibility (WCAG 2.2 AA) and theme integrity, produces the
+#   human-readable walkthrough + sequence diagrams, and runs the scanners CI
+#   does NOT (secrets, SAST). It is the better tool for *explaining* a change and
+#   for *what the browser receives*.
+#
+# OUT OF SCOPE (do not report — owned elsewhere, avoids double-spend):
+#   • PHP logic, bugs, security-in-code, query/N+1 cost, Octane safety, Laravel/
+#     Livewire idiom, tests .................... Qodo Merge (.pr_agent.toml, /review + /improve)
+#   • Code style / PSR-12 / static analysis ...... CI (Pint + PHPStan-max + Rector, blocking)
+#
+# TRIGGER: on-demand only. Invoke with `@coderabbitai review` (or `full review`).
+# Use it when a PR touches views/assets, or when you want a readable walkthrough.
+# Seat/quota "review paused" notices come from app.coderabbit.ai, not this file —
+# but auto_review:false + review_status:false stop the per-PR status spam.
+# ─────────────────────────────────────────────────────────────────────────────
+
 language: en-US
-tone_instructions: "Direct, practical, no fluff. Flag real problems, skip cosmetic nitpicks."
 early_access: true
+
+tone_instructions: >-
+  Senior front-end performance & accessibility engineer on a server-rendered
+  Laravel app (Blade + Livewire + Alpine, no SPA bundle). Direct, evidence-based.
+  Every finding names a user-facing cost (LCP/CLS/TTFB, a WCAG 2.2 criterion, or a
+  broken theme token) and a concrete fix. PHP logic, bugs and tests belong to Qodo;
+  code style belongs to Pint/CI — do not report either.
 
 reviews:
   profile: assertive
-  high_level_summary: true
-  sequence_diagrams: true
+  request_changes_workflow: false
+
+  # ── Comprehension output: keep the genuinely useful, cut the filler ────────
+  high_level_summary: true      # CodeRabbit's strength — keep
+  sequence_diagrams: true       # CodeRabbit's strength — keep
+  changed_files_summary: true
+  collapse_walkthrough: true
   estimate_code_review_effort: true
   assess_linked_issues: true
+  poem: false                   # pure token waste
+  suggested_reviewers: false    # solo-maintained repo
+  related_prs: false
+  review_status: false          # suppress the "review skipped/paused/quota" status comment
+
+  # ── Trigger: on-demand only (no auto-run, so no per-PR quota spam) ─────────
   auto_review:
-    enabled: true
-    auto_incremental_review: true
+    enabled: false
+    auto_incremental_review: false
     drafts: false
+
+  # ── Scope: never spend budget on generated, vendored, or non-view code ─────
   path_filters:
     - "!vendor/**"
     - "!node_modules/**"
@@ -20,116 +59,76 @@ reviews:
     - "!bootstrap/cache/**"
     - "!storage/**"
     - "!*.lock"
+
   path_instructions:
+    # ── Lane definition (applies everywhere) ─────────────────────────────────
     - path: "**"
       instructions: |
-        TEAL (The Essential Aggregator Library) is a self-hosted media tracker
-        for books, comics, movies/TV, and anime.
-        Stack: Laravel 12, Livewire 3, Alpine.js, FrankenPHP/Octane.
+        TEAL — self-hosted media tracker. Laravel 12 + Livewire 3 + Alpine +
+        Tailwind 3, FrankenPHP/Octane, PostgreSQL. Server-rendered: NO SPA
+        bundle, NO hydration — Web Vitals are won at TTFB and in the emitted HTML.
 
-        NON-NEGOTIABLE RULES:
-        1. NO CONTROLLERS. All routes point directly to Livewire components.
-           Flag any attempt to introduce a Controller layer.
-        2. "Movies & TV Shows" is a single module and data structure.
-           Do not suggest splitting them.
-        3. SUBPATH AWARENESS. The app may be hosted at `/teal`.
-           All URL generation must use route(), asset(), or URL::forceRootUrl.
-        4. OCTANE COMPATIBILITY. No static property leaks across requests.
-           All code must be state-safe for persistent-worker runtimes.
+        YOUR LANE: the presentation layer (Blade / CSS / assets) for Core Web
+        Vitals + WCAG 2.2 AA + theme integrity, plus the walkthrough and the
+        secret/SAST scan. Do NOT review PHP logic, bugs, security-in-code, query
+        cost, Octane safety, idiom, or tests — Qodo owns those. Do NOT comment on
+        formatting/style — Pint + CI own that. If a PR is PHP-only with no view
+        or asset change, say so and keep the review to a one-line summary.
 
-    - path: "app/Livewire/**/*.php"
-      instructions: |
-        Livewire 3 full-page components (no controllers exist).
-        Check for:
-        - Authorization: every DB query MUST be scoped to auth()->id().
-          A missing user_id scope is a data-leak vulnerability.
-        - Mass assignment: validate all wire:model-bound properties.
-        - XSS: flag unescaped Blade output ({!! !!}) unless explicitly sanitized.
-        - N+1 queries: eager-load relationships in index components.
-        - Wire:model bindings that expose fields which should not be user-editable
-          (e.g. user_id, metadata_fetched_at).
-        - Livewire lifecycle: ensure resetPage() is called when filters change.
-
-    - path: "app/Services/**/*.php"
-      instructions: |
-        Service classes wrap external API calls via Saloon PHP.
-        Check for:
-        - API keys leaking into logs, error messages, or exception traces.
-        - Missing null/empty checks on API response data before array access.
-        - Rate limiting compliance (Trakt/TMDB: 300ms, Jikan: 400ms,
-          ComicVine: 400ms, OpenLibrary: 250ms between requests).
-        - Graceful degradation when an API is down or returns unexpected format.
-
-    - path: "app/Jobs/**/*.php"
-      instructions: |
-        Background jobs for batch metadata fetching and cover downloads.
-        Check for:
-        - Proper queue job patterns (handle/failed methods).
-        - Rate limiting sleep() between API calls in loops.
-        - DB updates inside loops without chunking (N+1 write risk).
-        - Jobs must be idempotent (safe to retry).
-
+    # ── Blade — the Core Web Vitals & WCAG surface (primary focus) ───────────
     - path: "resources/views/**/*.blade.php"
       instructions: |
-        Blade templates using a CSS custom property theme system.
-        Check for:
-        - Hardcoded colors or Tailwind color classes (must use theme-* classes).
-        - Missing wire:key on Livewire @foreach loops.
-        - Unescaped output ({!! !!}) without prior sanitization.
-        - Accessibility: form labels, img alt text, ARIA on interactive elements.
-        - Forms must use @csrf.
+        Review the emitted HTML against WCAG 2.2 AA and Core Web Vitals. Each
+        finding is user-facing.
 
-    - path: "database/migrations/**/*.php"
+        LCP / CLS:
+        - <img> MUST carry width/height (or aspect-ratio) to reserve space — flag
+          dimensionless images (CLS).
+        - Below-the-fold imagery: loading="lazy" + decoding="async".
+        - The LCP image (cover/poster/hero) must NOT be lazy — prefer
+          fetchpriority="high".
+
+        WCAG 2.2 AA:
+        - 1.1.1: every <img> has meaningful alt (cover art → the title), or alt=""
+          if decorative.
+        - 1.3.1: every form control has <label for>/aria-label; icon-only
+          buttons/links have an accessible name.
+        - 2.4.7: visible focus preserved (no bare outline:none).
+        - 1.4.3: contrast meets AA. Flag hardcoded colors / raw Tailwind color
+          classes — they bypass the audited theme system (use theme-* tokens only).
+        - 4.1.2: Alpine/Livewire interactive elements expose role/state
+          (aria-expanded, aria-controls, aria-current).
+
+        Render cost:
+        - Every Livewire @foreach has a stable wire:key (missing key = full
+          re-render + focus loss).
+        - Flag unescaped output ({!! !!}) without sanitization — XSS via the view.
+
+    # ── Front-end assets — payload, caching, fonts ───────────────────────────
+    - path: "{vite.config.js,tailwind.config.js,postcss.config.js,resources/css/**,resources/js/**}"
       instructions: |
-        Check for:
-        - Missing indexes on foreign keys and frequently filtered columns
-          (user_id, status, imdb_id, mal_id, isbn, isbn13).
-        - down() method should reverse up().
-        - Nullable columns that need sensible defaults.
+        Front-end payload review.
+        - Keep Tailwind content globs tight so unused CSS is purged (smaller
+          critical CSS = faster FCP); flag broad safelists.
+        - Fonts: self-hosted, font-display: swap; no layout-shifting or
+          render-blocking third-party font requests.
+        - Assets via @vite/asset() so hashing + far-future caching apply and URLs
+          stay correct under any APP_URL/ASSET_URL root.
 
-    - path: "app/Models/**/*.php"
-      instructions: |
-        Eloquent models. All data is user-scoped (multi-tenant by user_id).
-        Check for:
-        - $fillable or $guarded properly configured.
-        - Casts defined for dates, enums, integers, floats.
-        - Relationships returning correct types with proper foreign keys.
-        - Missing user_id scope in any query scope methods.
-
-    - path: "tests/**/*.php"
-      instructions: |
-        Pest PHP tests.
-        Check for:
-        - Tests asserting meaningful behavior, not just status 200.
-        - Auth scoping: verify user A cannot access user B's data.
-        - Factory usage matching current model schema.
-        - Cleanup of test state between tests.
-
-    - path: "routes/web.php"
-      instructions: |
-        All routes must point to Livewire component classes.
-        No controller references. All authenticated routes must use
-        the ['auth', 'verified'] middleware group. Flag any debug
-        or test routes left behind.
-
+# ── Tools: only what CI does NOT already run (CI = Pint + PHPStan-max + Rector) ─
+# phpstan / phpcodesniffer / phpmd intentionally OMITTED — duplicating blocking CI.
 tools:
-  phpstan:
-    enabled: true
-  phpmd:
-    enabled: true
-  phpcodesniffer:
-    enabled: true
-  semgrep:
-    enabled: true
   gitleaks:
     enabled: true
   trufflehog:
     enabled: true
-  markdownlint:
+  semgrep:
+    enabled: true
+  actionlint:
     enabled: true
   yamllint:
     enabled: true
-  actionlint:
+  markdownlint:
     enabled: true
 
 chat:
@@ -137,8 +136,8 @@ chat:
 
 knowledge_base:
   learnings:
-    scope: local
+    scope: local        # let it learn your a11y/CWV preferences over time
   issues:
     scope: local
   code_guidelines:
-    enabled: true
+    enabled: false      # PHP guideline enforcement is Qodo's lane (best_practices.md)

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ database.sqlite
 *.md
 *.txt
 !README.md
+!best_practices.md
 
 **/caddy
 frankenphp

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,73 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Qodo Merge — TEAL code-review policy
+#
+# ROLE: Primary deep reviewer (the statistically stronger bug/security/test tool).
+#   Qodo's multi-agent review + RAG + /improve own everything in the PHP/code
+#   layer: correctness & bugs, security-in-code, query/N+1 cost, Octane safety,
+#   Laravel 12 / Livewire 3 idiom, and test-coverage gaps. Project coding rules
+#   live in best_practices.md (drives /improve).
+#
+# OUT OF SCOPE (do not report — owned elsewhere, avoids double-spend):
+#   • Blade/CSS/asset a11y, WCAG, Core Web Vitals, theme tokens, PR walkthrough
+#     ......................................... CodeRabbit (.coderabbit.yaml, @coderabbitai review)
+#   • Code style / PSR-12 / static analysis ... CI (Pint + PHPStan-max + Rector, blocking)
+#
+# TRIGGER: on-demand only. `pr_commands = []` => no tool auto-runs on open/push,
+# so an exhausted-quota / "paused for this user" notice can't spam every PR.
+# Invoke on a PR:  /review  (deep review)   ·   /improve  (code suggestions)
+# Seat assignment is managed in app.qodo.ai, not here.
+#
+# Stay in lane: presentation/a11y/CWV is CodeRabbit's; never duplicate it.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[config]
+publish_output = true
+verbosity_level = 1
+
+[github_app]
+# On-demand only: empty list = Qodo runs NO tool automatically on PR open/push.
+pr_commands = []
+
+[pr_reviewer]
+# Deep review, focused. num_max_findings caps volume so it stays high-signal.
+num_max_findings = 5
+require_security_review = true
+require_tests_review = true
+require_can_be_split_review = true
+require_score_review = true
+persistent_comment = true
+extra_instructions = """
+You are the PRIMARY deep reviewer for TEAL (Laravel 12 + Livewire 3 + Alpine +
+FrankenPHP/Octane + PostgreSQL). Own correctness, security-in-code, runtime/query
+cost, Octane safety, framework idiom and test coverage. Apply best_practices.md.
+
+Do NOT report: Blade/CSS/asset accessibility, WCAG, Core Web Vitals or theme
+tokens (CodeRabbit owns the presentation layer); and do NOT report formatting or
+PSR-12 style (Pint + CI are authoritative and blocking). Stay off both.
+
+Highest-priority findings, in order:
+1. Cross-tenant data leak — any DB query not scoped to auth()->id().
+2. Octane state leak — static mutable state or request data captured in
+   singletons/bindings that persists across requests on long-lived workers.
+3. N+1 / query cost — missing eager-loading, over-fetching, unbounded ->get(),
+   per-row writes in loops; these become TTFB.
+4. Missing/weak tests for new behavior, especially auth-scoping tests.
+5. Non-idiomatic Laravel 12 / Livewire 3 (see best_practices.md).
+Be specific; when something is correct but non-idiomatic, show the idiomatic form.
+"""
+
+[pr_code_suggestions]
+# /improve is Qodo's signature strength — keep it, but bounded and non-committable.
+num_code_suggestions_per_chunk = 3
+max_number_of_calls = 3
+commitable_code_suggestions = false
+extra_instructions = """
+Suggest only high-impact, project-idiomatic changes for Laravel 12 / Livewire 3 on
+Octane: enum-backed status, policy authorization, Saloon connector patterns,
+computed properties over recomputed queries, form objects, eager-loading, and
+Octane-safe state. Do NOT suggest accessibility/CWV changes (CodeRabbit's lane) or
+pure style reformatting (Pint's lane).
+"""
+
+[pr_description]
+generate_ai_title = false

--- a/best_practices.md
+++ b/best_practices.md
@@ -1,0 +1,64 @@
+# TEAL — coding best practices
+
+Consumed by Qodo Merge's `/improve` tool. Project-specific rules only; general
+"write clean code" advice is intentionally omitted. Style/PSR-12 is enforced by
+Pint + CI and is out of scope here. Accessibility / Core Web Vitals are
+CodeRabbit's lane and are out of scope here.
+
+## Architecture (non-negotiable)
+
+- **No controllers.** Routes point directly to Livewire 3 full-page components.
+  Reject any new `app/Http/Controllers` class or controller-style routing.
+- **Octane / persistent-worker safety.** Workers are long-lived. No static mutable
+  state, no request data captured in singletons or container bindings, no
+  unbounded static caches. State must not leak across requests.
+- **Single module boundaries.** "Movies & TV Shows" is one module and one data
+  structure — do not split it.
+- **URL portability.** Production is a subdomain (`teal.dotmavriq.life`) and
+  self-hosters may mount elsewhere. Derive every URL/asset from `APP_URL`/
+  `ASSET_URL` via `route()`, `asset()`, `@vite`, or `URL::forceRootUrl` — never
+  hardcode an absolute path or scheme.
+
+## Multi-tenancy & authorization
+
+- Every model is user-scoped (`user_id` FK, cascade delete). Every query must be
+  scoped to `auth()->id()`; a missing scope is a cross-tenant data leak.
+- Authorization goes through policies (auto-discovered). New models need a policy
+  and new query paths need scoping tests proving user A cannot read user B's data.
+- Guard `wire:model` bindings: never bind `user_id`, `metadata_fetched_at`, or
+  other non-user-editable fields. Validate all bound properties.
+
+## Performance (code layer)
+
+- Index/list components must eager-load (`with()`) every relationship the view
+  touches. No lazy relationship access inside loops.
+- Select only needed columns; paginate; avoid `->get()` on unbounded sets.
+- Call `resetPage()` when filters/search change.
+- Jobs: chunk DB writes (no per-row updates in loops), stay idempotent, and keep
+  rate-limit `sleep()`s so retries don't stampede the upstream API.
+
+## External APIs (Saloon)
+
+- One connector per API + request classes; resolve services via `app(Service::class)`.
+- Synchronous external HTTP during a web request is a TTFB hazard — queue it.
+- Respect cache TTLs; a cache miss must not fan out to N sequential calls on a
+  user-facing path.
+- Never let API keys reach logs, exceptions, or traces. Null-check response data
+  before array access; degrade gracefully when an API is down.
+
+## Data & schema
+
+- Index foreign keys and frequently filtered/sorted columns (`user_id`, `status`,
+  and external IDs: `imdb_id`, `mal_id`, `isbn`, `isbn13`). Prefer composite
+  `(user_id, status)` indexes matching index-page filters.
+- `down()` must reverse `up()`; new columns need sane defaults to avoid rewrite
+  locks on large tables.
+- Models: configure `$fillable`/`$guarded`; cast dates, enums, ints, floats.
+
+## Conventions
+
+- `declare(strict_types=1)` in every PHP file.
+- Status is an enum (`ReadingStatus`, `WatchingStatus`, …) with `label()`/`color()`.
+- Forms display dates as **DD/MM/YYYY**; storage is **Y-m-d**.
+- Import services return `['imported' => int, 'skipped' => int, 'errors' => array]`.
+- Tests (Pest 3): assert real behavior, not just HTTP 200; cover auth scoping.


### PR DESCRIPTION
## What

Reworks the two AI review bots into **non-overlapping, on-demand specialists** — cutting token burn, stopping the per-PR "paused/quota" spam, and assigning each tool the lane it's documented to be best at.

## Topology

| Layer | Owner |
|---|---|
| PHP: bugs, security-in-code, N+1/query cost, Octane safety, Laravel 12 / Livewire 3 idiom, tests, `/improve` suggestions | **Qodo** (`.pr_agent.toml`) — highest measured bug-detection F1; multi-agent + RAG; `/improve` is its signature |
| Blade a11y / WCAG 2.2 AA / Core Web Vitals / theme tokens, walkthrough + sequence diagrams, secret/SAST scan | **CodeRabbit** (`.coderabbit.yaml`) — best at readable summaries + reading the rendered HTML/CSS |
| Style / PSR-12 / static analysis | **CI** (Pint + PHPStan-max + Rector, blocking) |

Each config explicitly defers the other two lanes, so the bots don't double-report.

## Redundancy removed
- Dropped CodeRabbit `phpstan` / `phpcodesniffer` / `phpmd` — CI already runs these, blocking. Kept only what CI lacks (`gitleaks`, `trufflehog`, `semgrep`, `actionlint`, `yamllint`, `markdownlint`).
- N+1 / query-perf is now **Qodo-only**; CodeRabbit keeps rendered-output CWV only.
- Architecture/idiom rules consolidated into a single `best_practices.md` (Qodo's `/improve` mechanism).

## Spam control
- Both bots **on-demand**: CodeRabbit `auto_review.enabled: false`; Qodo `pr_commands = []`. Nothing posts until invoked (`/review`, `/improve`, or `@coderabbitai review`).
- CodeRabbit `review_status: false` suppresses the "review skipped/paused/quota" status comment. `poem` / `suggested_reviewers` / `related_prs` off to trim walkthrough filler.

> Note: the **"paused for this user"** seat notice and the **free-tier large-PR cap** are account-side (app.coderabbit.ai / app.qodo.ai) and can't be fixed from the repo — but on-demand triggering stops them from appearing on every PR.

## Also
- Reframed the stale `/teal` subpath rule as APP_URL-portable URL generation (prod is now the `teal.dotmavriq.life` subdomain).
- Un-ignored `best_practices.md` (blanket `*.md` ignore) so Qodo can read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive coding standards and best practices guide for the development team.

* **Chores**
  * Updated development configuration and review policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->