### PR TITLE
fix(welcome): mobile layout for landing page

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -87,7 +87,7 @@
         }
         .nav .wrap { display: flex; align-items: center; justify-content: space-between; height: 72px; }
         .nav .wordmark { font-size: 1.7rem; }
-        .nav-actions { display: flex; align-items: center; gap: .6rem; }
+        .nav-actions { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap; }
 
         /* ── Hero ────────────────────────────────── */
         .hero { padding: 64px 0 28px; }
@@ -202,6 +202,29 @@
             .hero-art { order: -1; max-width: 340px; }
             .cards { grid-template-columns: repeat(2, 1fr); }
             .features { grid-template-columns: 1fr; }
+            /* Stacked terminal: wrap the long clone URL instead of inner scroll */
+            .terminal pre { white-space: pre-wrap; overflow-wrap: anywhere; }
+        }
+        @media (max-width: 560px) {
+            .wrap { padding: 0 16px; }
+
+            /* Nav: let actions drop onto their own line instead of overflowing */
+            .nav .wrap { height: auto; min-height: 64px; padding-top: 12px; padding-bottom: 12px; flex-wrap: wrap; gap: 10px; }
+            .nav .nav-actions { justify-content: flex-start; }
+
+            /* CTAs: full-width, centred — bigger tap targets, no overflow */
+            .hero-cta .btn { flex: 1 1 100%; justify-content: center; }
+            .maker .nav-actions { width: 100%; }
+            .maker .nav-actions .btn { flex: 1 1 100%; justify-content: center; }
+
+            /* Terminal code block: shrink + tighten so it reads on a phone */
+            .terminal { box-shadow: 4px 4px 0 var(--teal-700); }
+            .terminal pre { font-size: .78rem; padding: 14px; line-height: 1.6; }
+
+            /* Footer: stack wordmark above links, drop the left-margin hack */
+            footer .wrap { flex-direction: column; align-items: flex-start; gap: 14px; }
+            footer .wrap > div { display: flex; flex-wrap: wrap; gap: 8px 18px; }
+            footer a { margin-left: 0; }
         }
         @media (prefers-reduced-motion: reduce) {
             .btn, .card { transition: none; }


### PR DESCRIPTION
## What

The marketing landing page (`teal.dotmavriq.life`, `resources/views/welcome.blade.php`) overflowed horizontally and looked unoptimised on phones — specifically the terminal/code block and the bottom button row.

## Fixes
- **`.nav-actions` wraps** (`flex-wrap`) so the bottom **Support / Star on GitHub / Log in** row can no longer overflow the viewport (it was forcing page-level horizontal scroll).
- **New `560px` breakpoint:**
  - Bottom CTAs + hero CTAs become **full-width stacked** (bigger tap targets).
  - Top-nav actions wrap onto their own line; nav height becomes `auto`.
  - Footer stacks the wordmark above its links and drops the `margin-left` hack.
- **Terminal code block:** the long `git clone …` URL now **wraps** once the layout stacks (`pre-wrap` + `overflow-wrap`) instead of inner horizontal scrolling, with smaller/tighter mono type on phones.

## Verification
Rendered at **390px** (iPhone width) via Playwright — **0px horizontal overflow**; nav, terminal, bottom CTAs and footer all confirmed visually. CSS-only change inside the page's inline `<style>`, no Vite rebuild required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved responsive design for mobile devices. Navigation items now wrap properly on smaller screens, and content displays better without requiring horizontal scrolling. Layout adjustments at smaller viewport sizes ensure full-width call-to-action buttons and optimized footer spacing for improved mobile usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->