### PR TITLE
chore(deps): bump livewire/volt floor to ^1.10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "laravel/octane": "^2.14",
         "laravel/tinker": "^3.0",
         "livewire/livewire": "^4.0",
-        "livewire/volt": "^1.7.0",
+        "livewire/volt": "^1.10.0",
         "saloonphp/cache-plugin": "^3.1",
         "saloonphp/laravel-plugin": "^4.0",
         "saloonphp/rate-limit-plugin": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dcdcca4c44dc179da889440778a6cb45",
+    "content-hash": "5e446769626b2ae3de78a787d4332947",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
## What
Bump the `livewire/volt` constraint from `^1.7.0` to `^1.10.0`. Lock is unchanged (`v1.10.5`).

## Why (closes #32)
Ticket #32 assumed a Volt **2.x** companion release for Livewire 4. That release **never shipped** — the latest published Volt is `v1.10.5`. Meanwhile, Volt `1.10.x` already declares `livewire/livewire: ^3.6.1|^4.0` and has been running against `livewire@4.2.3` (incl. prod). So the compatibility concern behind #32 is already met; there is nothing to upgrade *to*.

This bump just moves the floor off the pre-Livewire-4 `^1.7.0` to document the actually-supported line.

## Verification
- `composer validate` ✅ / lock up to date ✅
- Volt still `v1.10.5` (no dependency churn)
- `php artisan route:list` boots clean; `login` route resolves via Volt's `VoltManager` on Livewire 4 ✅

Closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a package dependency to a newer compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->