### PR TITLE
Per-user encrypted API keys with instance fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,4 +69,18 @@ TMDB_ACCESS_TOKEN=
 
 TRAKT_CLIENT_ID=
 
+COMIC_VINE_API_KEY=
+IGDB_CLIENT_ID=
+IGDB_CLIENT_SECRET=
+BGG_API_TOKEN=
+DISCOGS_TOKEN=
+SETLISTFM_API_KEY=
+
+# Per-user API keys (issue #36). Controls how a user's own keys interact with
+# the shared keys above:
+#   both   - user key overrides, .env is the fallback (default)
+#   shared - .env only; user keys are ignored and the settings UI is hidden
+#   byo    - "bring your own"; only user keys are used, no .env fallback
+API_KEYS_POLICY=both
+
 VITE_APP_NAME="${APP_NAME}"

--- a/app/Livewire/Profile/ApiKeysForm.php
+++ b/app/Livewire/Profile/ApiKeysForm.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Profile;
+
+use App\Models\User;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+/**
+ * Lets a user manage their own third-party API keys. Keys are stored encrypted
+ * and never rendered back in full — only a masked hint (`••••3f2a`).
+ */
+class ApiKeysForm extends Component
+{
+    /**
+     * Plaintext entered by the user, keyed by credential slug. Always starts
+     * empty and is cleared after saving so a full key is never re-rendered.
+     *
+     * @var array<string, string>
+     */
+    public array $inputs = [];
+
+    public function mount(): void
+    {
+        foreach ($this->slugs() as $slug) {
+            $this->inputs[$slug] = '';
+        }
+    }
+
+    public function save(): void
+    {
+        if ($this->policy() === 'shared') {
+            return;
+        }
+
+        /** @var array<string, array<string, string|null>> $rules */
+        $rules = [];
+        foreach ($this->slugs() as $slug) {
+            $rules["inputs.$slug"] = ['nullable', 'string', 'max:500'];
+        }
+        $this->validate($rules);
+
+        $user = $this->user();
+        $stored = 0;
+
+        foreach ($this->slugs() as $slug) {
+            $value = trim($this->inputs[$slug] ?? '');
+            if ($value === '') {
+                continue;
+            }
+
+            $user->apiKeys()->updateOrCreate(
+                ['service' => $slug],
+                ['key' => $value],
+            );
+            $this->inputs[$slug] = '';
+            $stored++;
+        }
+
+        $user->unsetRelation('apiKeys');
+
+        if ($stored > 0) {
+            session()->flash('api-keys-status', "Saved {$stored} key".($stored === 1 ? '' : 's').'.');
+        }
+    }
+
+    public function remove(string $slug): void
+    {
+        $this->user()->apiKeys()->where('service', $slug)->delete();
+        $this->user()->unsetRelation('apiKeys');
+        session()->flash('api-keys-status', 'Key removed.');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.profile.api-keys-form', [
+            'services' => config('api_keys.services', []),
+            'states' => $this->states(),
+            'policy' => $this->policy(),
+        ]);
+    }
+
+    /**
+     * Per-slug display state: where the effective value comes from and a masked
+     * hint for a user-set key. Never contains a full key.
+     *
+     * @return array<string, array{source: string, masked: string|null}>
+     */
+    protected function states(): array
+    {
+        $user = $this->user();
+        $states = [];
+
+        foreach ($this->fields() as $slug => $configPath) {
+            $userKey = $user->apiKeyFor($slug);
+            if ($userKey !== null && $userKey !== '') {
+                $states[$slug] = ['source' => 'user', 'masked' => $this->mask($userKey)];
+
+                continue;
+            }
+
+            $instance = config($configPath);
+            $states[$slug] = [
+                'source' => is_string($instance) && $instance !== '' ? 'instance' : 'none',
+                'masked' => null,
+            ];
+        }
+
+        return $states;
+    }
+
+    protected function mask(string $key): string
+    {
+        $tail = mb_substr($key, -4);
+
+        return '••••'.($tail === '' ? '' : $tail);
+    }
+
+    /**
+     * @return array<string, string> slug => config path
+     */
+    protected function fields(): array
+    {
+        /** @var array<string, array{fields: array<string, array{config: string}>}> $services */
+        $services = config('api_keys.services', []);
+
+        $fields = [];
+        foreach ($services as $service) {
+            foreach ($service['fields'] as $slug => $field) {
+                $fields[$slug] = $field['config'];
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function slugs(): array
+    {
+        return array_keys($this->fields());
+    }
+
+    protected function policy(): string
+    {
+        $policy = config('api_keys.policy', 'both');
+
+        return is_string($policy) ? $policy : 'both';
+    }
+
+    protected function user(): User
+    {
+        $user = Auth::user();
+        abort_unless($user instanceof User, 403);
+
+        return $user;
+    }
+}

--- a/app/Livewire/Profile/ApiKeysForm.php
+++ b/app/Livewire/Profile/ApiKeysForm.php
@@ -114,9 +114,7 @@ class ApiKeysForm extends Component
 
     protected function mask(string $key): string
     {
-        $tail = mb_substr($key, -4);
-
-        return '••••'.($tail === '' ? '' : $tail);
+        return '••••'.mb_substr($key, -4);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -110,4 +110,24 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->hasMany(Concert::class);
     }
+
+    /** @return HasMany<UserApiKey, $this> */
+    public function apiKeys(): HasMany
+    {
+        return $this->hasMany(UserApiKey::class);
+    }
+
+    /**
+     * The user's decrypted key for a credential slug (e.g. "tmdb.access_token"),
+     * or null if they have not set one. Uses the already-loaded relation when
+     * available to avoid extra queries.
+     */
+    public function apiKeyFor(string $service): ?string
+    {
+        $record = $this->relationLoaded('apiKeys')
+            ? $this->apiKeys->firstWhere('service', $service)
+            : $this->apiKeys()->where('service', $service)->first();
+
+        return $record instanceof UserApiKey ? $record->plainKey() : null;
+    }
 }

--- a/app/Models/UserApiKey.php
+++ b/app/Models/UserApiKey.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Database\Factories\UserApiKeyFactory;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Crypt;
+
+/**
+ * A single third-party credential owned by a user, encrypted at rest.
+ *
+ * @property int $id
+ * @property int $user_id
+ * @property string $service credential slug, e.g. "tmdb_access_token"
+ * @property string|null $key decrypted on access; null if it cannot be decrypted
+ */
+class UserApiKey extends Model
+{
+    /** @use HasFactory<UserApiKeyFactory> */
+    use HasFactory;
+
+    /** @var list<string> */
+    protected $fillable = [
+        'service',
+        'key',
+    ];
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Encrypt on write, decrypt on read. A raw database dump only ever holds the
+     * ciphertext. Reading a value that cannot be decrypted (e.g. APP_KEY was
+     * rotated) yields null rather than throwing and taking down the app.
+     *
+     * @return Attribute<string|null, string>
+     */
+    protected function key(): Attribute
+    {
+        return Attribute::make(
+            get: function (mixed $value): ?string {
+                if (! is_string($value) || $value === '') {
+                    return null;
+                }
+
+                try {
+                    return Crypt::decryptString($value);
+                } catch (DecryptException) {
+                    return null;
+                }
+            },
+            set: fn (mixed $value): string => Crypt::encryptString(is_string($value) ? $value : ''),
+        );
+    }
+
+    /**
+     * The decrypted key, or null if unset / undecryptable.
+     */
+    public function plainKey(): ?string
+    {
+        $value = $this->key;
+
+        return $value !== null && $value !== '' ? $value : null;
+    }
+}

--- a/app/Services/Saloon/Bgg/BggConnector.php
+++ b/app/Services/Saloon/Bgg/BggConnector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Saloon\Bgg;
 
+use App\Support\ApiKey;
 use Saloon\Http\Connector;
 use Saloon\Traits\Plugins\HasTimeout;
 
@@ -22,7 +23,7 @@ class BggConnector extends Connector
 
     public function defaultHeaders(): array
     {
-        $token = config('services.bgg.api_token');
+        $token = ApiKey::resolve('bgg_api_token');
 
         if (is_string($token) && $token !== '') {
             return [

--- a/app/Services/Saloon/ComicVine/ComicVineConnector.php
+++ b/app/Services/Saloon/ComicVine/ComicVineConnector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Saloon\ComicVine;
 
+use App\Support\ApiKey;
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Cacheable;
 use Saloon\CachePlugin\Contracts\Driver;
@@ -44,7 +45,7 @@ class ComicVineConnector extends Connector implements Cacheable
     protected function defaultQuery(): array
     {
         return [
-            'api_key' => config('services.comic_vine.api_key'),
+            'api_key' => ApiKey::resolve('comic_vine_api_key'),
             'format' => 'json',
         ];
     }

--- a/app/Services/Saloon/Discogs/DiscogsConnector.php
+++ b/app/Services/Saloon/Discogs/DiscogsConnector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Saloon\Discogs;
 
+use App\Support\ApiKey;
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Cacheable;
 use Saloon\CachePlugin\Contracts\Driver;
@@ -30,7 +31,7 @@ class DiscogsConnector extends Connector implements Cacheable
 
     protected function defaultHeaders(): array
     {
-        $token = config('services.discogs.token', '');
+        $token = ApiKey::resolve('discogs_token');
 
         return [
             'Accept' => 'application/json',

--- a/app/Services/Saloon/Igdb/IgdbConnector.php
+++ b/app/Services/Saloon/Igdb/IgdbConnector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Saloon\Igdb;
 
+use App\Support\ApiKey;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Saloon\Http\Connector;
@@ -25,17 +26,28 @@ class IgdbConnector extends Connector
     public function defaultHeaders(): array
     {
         return [
-            'Client-ID' => config('services.igdb.client_id'),
+            'Client-ID' => ApiKey::resolve('igdb_client_id'),
             'Authorization' => 'Bearer '.$this->getAccessToken(),
         ];
     }
 
     protected function getAccessToken(): string
     {
-        $token = Cache::remember('igdb_access_token', 3600, function () {
+        $clientId = ApiKey::resolve('igdb_client_id');
+        $clientSecret = ApiKey::resolve('igdb_client_secret');
+
+        if ($clientId === null || $clientSecret === null) {
+            return '';
+        }
+
+        // Key the cached token by the credentials so a per-user client_id never
+        // reuses another user's (or the instance's) Twitch token.
+        $cacheKey = 'igdb_access_token:'.hash('sha256', $clientId.'|'.$clientSecret);
+
+        $token = Cache::remember($cacheKey, 3600, function () use ($clientId, $clientSecret) {
             $response = Http::post('https://id.twitch.tv/oauth2/token', [
-                'client_id' => config('services.igdb.client_id'),
-                'client_secret' => config('services.igdb.client_secret'),
+                'client_id' => $clientId,
+                'client_secret' => $clientSecret,
                 'grant_type' => 'client_credentials',
             ]);
 

--- a/app/Services/Saloon/SetlistFm/SetlistFmConnector.php
+++ b/app/Services/Saloon/SetlistFm/SetlistFmConnector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Saloon\SetlistFm;
 
+use App\Support\ApiKey;
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Cacheable;
 use Saloon\CachePlugin\Contracts\Driver;
@@ -32,7 +33,7 @@ class SetlistFmConnector extends Connector implements Cacheable
     {
         return [
             'Accept' => 'application/json',
-            'x-api-key' => config('services.setlistfm.api_key', ''),
+            'x-api-key' => ApiKey::resolve('setlistfm_api_key') ?? '',
         ];
     }
 

--- a/app/Services/Saloon/Tmdb/TmdbConnector.php
+++ b/app/Services/Saloon/Tmdb/TmdbConnector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Saloon\Tmdb;
 
+use App\Support\ApiKey;
 use Illuminate\Support\Facades\Cache;
 use Saloon\CachePlugin\Contracts\Cacheable;
 use Saloon\CachePlugin\Contracts\Driver;
@@ -40,7 +41,7 @@ class TmdbConnector extends Connector implements Cacheable
             'Accept' => 'application/json',
         ];
 
-        $accessToken = config('services.tmdb.access_token');
+        $accessToken = ApiKey::resolve('tmdb_access_token');
         if (is_string($accessToken) && $accessToken !== '') {
             $headers['Authorization'] = 'Bearer '.$accessToken;
         }
@@ -53,7 +54,7 @@ class TmdbConnector extends Connector implements Cacheable
         $query = [];
 
         // If no bearer token, fall back to API key in query params
-        if (! config('services.tmdb.access_token') && $apiKey = config('services.tmdb.api_key')) {
+        if (! ApiKey::resolve('tmdb_access_token') && $apiKey = ApiKey::resolve('tmdb_api_key')) {
             $query['api_key'] = $apiKey;
         }
 

--- a/app/Services/Saloon/Trakt/TraktConnector.php
+++ b/app/Services/Saloon/Trakt/TraktConnector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Saloon\Trakt;
 
+use App\Support\ApiKey;
 use Saloon\Http\Connector;
 use Saloon\Traits\Plugins\AcceptsJson;
 use Saloon\Traits\Plugins\HasTimeout;
@@ -27,7 +28,7 @@ class TraktConnector extends Connector
         return [
             'Content-Type' => 'application/json',
             'trakt-api-version' => '2',
-            'trakt-api-key' => config('services.trakt.client_id'),
+            'trakt-api-key' => ApiKey::resolve('trakt_client_id'),
         ];
     }
 }

--- a/app/Support/ApiKey.php
+++ b/app/Support/ApiKey.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Resolves a third-party credential following the instance policy:
+ *
+ *   1. the authenticated user's own key for the slug (unless policy = shared)
+ *   2. the instance-level value from config/services.php (unless policy = byo)
+ *   3. null — the feature is unconfigured and should degrade gracefully
+ *
+ * Keys are always scoped to Auth::user(); a caller can never resolve another
+ * user's key. Outside a request (e.g. queue jobs) there is no authenticated
+ * user, so resolution falls back to the instance key.
+ */
+final class ApiKey
+{
+    /**
+     * @return array<string, string> map of credential slug => config path
+     */
+    public static function slugMap(): array
+    {
+        /** @var array<string, array{fields: array<string, array{config: string}>}> $services */
+        $services = config('api_keys.services', []);
+
+        $map = [];
+        foreach ($services as $service) {
+            foreach ($service['fields'] as $slug => $field) {
+                $map[$slug] = $field['config'];
+            }
+        }
+
+        return $map;
+    }
+
+    public static function resolve(string $slug): ?string
+    {
+        $configPath = self::slugMap()[$slug] ?? null;
+        if ($configPath === null) {
+            return null;
+        }
+
+        /** @var string $policy */
+        $policy = config('api_keys.policy', 'both');
+
+        if ($policy !== 'shared') {
+            $user = Auth::user();
+            if ($user instanceof User) {
+                $userKey = $user->apiKeyFor($slug);
+                if ($userKey !== null && $userKey !== '') {
+                    return $userKey;
+                }
+            }
+        }
+
+        if ($policy === 'byo') {
+            return null;
+        }
+
+        $value = config($configPath);
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/config/api_keys.php
+++ b/config/api_keys.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Instance key policy
+    |--------------------------------------------------------------------------
+    |
+    | Controls how per-user keys interact with the instance-level keys in
+    | config/services.php (.env). The admin sets this via API_KEYS_POLICY:
+    |
+    |   both   - user key overrides, .env is the fallback (default)
+    |   shared - .env only; user keys are ignored and the settings UI is hidden
+    |   byo    - "bring your own"; only user keys are used, no .env fallback
+    |
+    */
+
+    'policy' => env('API_KEYS_POLICY', 'both'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Supported credentials
+    |--------------------------------------------------------------------------
+    |
+    | Each field maps a credential slug (stored in user_api_keys.service) to the
+    | config/services.php path it overrides. Fields are grouped by service purely
+    | for display. OpenLibrary and Jikan need no keys, so they are absent.
+    |
+    */
+
+    'services' => [
+        'tmdb' => [
+            'label' => 'TMDB',
+            'description' => 'Movies & TV metadata',
+            'fields' => [
+                'tmdb_access_token' => [
+                    'label' => 'API Read Access Token (v4)',
+                    'config' => 'services.tmdb.access_token',
+                ],
+                'tmdb_api_key' => [
+                    'label' => 'API Key (v3, optional fallback)',
+                    'config' => 'services.tmdb.api_key',
+                ],
+            ],
+        ],
+        'comic_vine' => [
+            'label' => 'ComicVine',
+            'description' => 'Comics metadata',
+            'fields' => [
+                'comic_vine_api_key' => [
+                    'label' => 'API Key',
+                    'config' => 'services.comic_vine.api_key',
+                ],
+            ],
+        ],
+        'igdb' => [
+            'label' => 'IGDB',
+            'description' => 'Games metadata (Twitch OAuth)',
+            'fields' => [
+                'igdb_client_id' => [
+                    'label' => 'Client ID',
+                    'config' => 'services.igdb.client_id',
+                ],
+                'igdb_client_secret' => [
+                    'label' => 'Client Secret',
+                    'config' => 'services.igdb.client_secret',
+                ],
+            ],
+        ],
+        'bgg' => [
+            'label' => 'BoardGameGeek',
+            'description' => 'Board games metadata',
+            'fields' => [
+                'bgg_api_token' => [
+                    'label' => 'API Token',
+                    'config' => 'services.bgg.api_token',
+                ],
+            ],
+        ],
+        'discogs' => [
+            'label' => 'Discogs',
+            'description' => 'Albums metadata',
+            'fields' => [
+                'discogs_token' => [
+                    'label' => 'Token',
+                    'config' => 'services.discogs.token',
+                ],
+            ],
+        ],
+        'setlistfm' => [
+            'label' => 'Setlist.fm',
+            'description' => 'Concerts & setlists',
+            'fields' => [
+                'setlistfm_api_key' => [
+                    'label' => 'API Key',
+                    'config' => 'services.setlistfm.api_key',
+                ],
+            ],
+        ],
+        'trakt' => [
+            'label' => 'Trakt',
+            'description' => 'Movie/TV fallback metadata',
+            'fields' => [
+                'trakt_client_id' => [
+                    'label' => 'Client ID',
+                    'config' => 'services.trakt.client_id',
+                ],
+            ],
+        ],
+    ],
+
+];

--- a/database/factories/UserApiKeyFactory.php
+++ b/database/factories/UserApiKeyFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\UserApiKey;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<UserApiKey>
+ */
+class UserApiKeyFactory extends Factory
+{
+    protected $model = UserApiKey::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'service' => 'tmdb.access_token',
+            'key' => $this->faker->sha256(),
+        ];
+    }
+}

--- a/database/migrations/2026_07_07_000000_create_user_api_keys_table.php
+++ b/database/migrations/2026_07_07_000000_create_user_api_keys_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_api_keys', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            // The credential slug, e.g. "tmdb.access_token" (see config/api_keys.php).
+            $table->string('service');
+            // Encrypted at rest via Laravel's Crypt (the `encrypted` cast). A raw
+            // database dump never exposes the plaintext key.
+            $table->text('key');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'service']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_api_keys');
+    }
+};

--- a/resources/views/livewire/profile/api-keys-form.blade.php
+++ b/resources/views/livewire/profile/api-keys-form.blade.php
@@ -1,0 +1,72 @@
+<section>
+    <header>
+        <h2 class="text-lg font-medium text-theme-text-primary">
+            {{ __('API Keys') }}
+        </h2>
+
+        <p class="mt-1 text-sm text-theme-text-tertiary">
+            {{ __('Optionally provide your own keys for the external metadata services. Keys are encrypted at rest and used only for your account. OpenLibrary and Jikan (anime) need no key.') }}
+        </p>
+
+        @if ($policy === 'byo')
+            <p class="mt-2 text-sm text-theme-warning-text">
+                {{ __('This instance requires you to bring your own keys — there is no shared fallback.') }}
+            </p>
+        @endif
+    </header>
+
+    @if ($policy === 'shared')
+        <p class="mt-6 text-sm text-theme-text-secondary">
+            {{ __('The administrator has configured shared instance keys, so per-user keys are disabled here.') }}
+        </p>
+    @else
+        @if (session('api-keys-status'))
+            <p class="mt-4 text-sm font-medium text-theme-success">{{ session('api-keys-status') }}</p>
+        @endif
+
+        <form wire:submit="save" class="mt-6 space-y-8">
+            @foreach ($services as $service)
+                <div class="space-y-4">
+                    <div>
+                        <h3 class="text-sm font-semibold text-theme-text-primary">{{ $service['label'] }}</h3>
+                        <p class="text-xs text-theme-text-muted">{{ $service['description'] }}</p>
+                    </div>
+
+                    @foreach ($service['fields'] as $slug => $field)
+                        @php($state = $states[$slug])
+                        <div>
+                            <div class="flex items-center justify-between gap-2">
+                                <x-input-label :for="$slug" :value="$field['label']" />
+
+                                @if ($state['source'] === 'user')
+                                    <span class="inline-flex items-center gap-2 text-xs text-theme-text-tertiary">
+                                        <span class="font-mono">{{ $state['masked'] }}</span>
+                                        <button type="button" wire:click="remove('{{ $slug }}')"
+                                            class="text-theme-danger-text hover:underline">{{ __('Remove') }}</button>
+                                    </span>
+                                @elseif ($state['source'] === 'instance')
+                                    <span class="text-xs text-theme-text-muted">{{ __('Using instance key') }}</span>
+                                @else
+                                    <span class="text-xs text-theme-text-muted">{{ __('Not set') }}</span>
+                                @endif
+                            </div>
+
+                            <x-text-input
+                                wire:model="inputs.{{ $slug }}"
+                                :id="$slug"
+                                type="password"
+                                autocomplete="off"
+                                class="mt-1 block w-full"
+                                :placeholder="$state['source'] === 'user' ? __('Enter a new value to replace') : __('Paste your key')" />
+                            <x-input-error class="mt-2" :messages="$errors->get('inputs.'.$slug)" />
+                        </div>
+                    @endforeach
+                </div>
+            @endforeach
+
+            <div class="flex items-center gap-4">
+                <x-primary-button>{{ __('Save keys') }}</x-primary-button>
+            </div>
+        </form>
+    @endif
+</section>

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -27,6 +27,12 @@
 
             <div class="p-4 sm:p-8 bg-theme-card-bg shadow sm:rounded-lg">
                 <div class="max-w-xl">
+                    <livewire:profile.api-keys-form />
+                </div>
+            </div>
+
+            <div class="p-4 sm:p-8 bg-theme-card-bg shadow sm:rounded-lg">
+                <div class="max-w-xl">
                     <livewire:profile.delete-user-form />
                 </div>
             </div>

--- a/tests/Feature/UserApiKeyTest.php
+++ b/tests/Feature/UserApiKeyTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Profile\ApiKeysForm;
+use App\Models\User;
+use App\Models\UserApiKey;
+use App\Support\ApiKey;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    config()->set('api_keys.policy', 'both');
+    config()->set('services.tmdb.access_token', 'instance-token');
+});
+
+it('stores the key encrypted at rest, not in plaintext', function (): void {
+    $this->user->apiKeys()->create([
+        'service' => 'tmdb_access_token',
+        'key' => 'super-secret-user-key',
+    ]);
+
+    $raw = DB::table('user_api_keys')->where('user_id', $this->user->id)->value('key');
+
+    expect($raw)->not->toContain('super-secret-user-key');
+    expect($this->user->fresh()->apiKeyFor('tmdb_access_token'))->toBe('super-secret-user-key');
+});
+
+it('returns null for a decrypt failure instead of throwing', function (): void {
+    // Write a value that is not valid ciphertext.
+    $key = UserApiKey::factory()->create([
+        'user_id' => $this->user->id,
+        'service' => 'tmdb_access_token',
+    ]);
+    DB::table('user_api_keys')->where('id', $key->id)->update(['key' => 'not-encrypted']);
+
+    expect($this->user->fresh()->apiKeyFor('tmdb_access_token'))->toBeNull();
+});
+
+describe('ApiKey::resolve', function (): void {
+    it('prefers the user key over the instance key (both policy)', function (): void {
+        $this->user->apiKeys()->create(['service' => 'tmdb_access_token', 'key' => 'user-token']);
+
+        $this->actingAs($this->user);
+
+        expect(ApiKey::resolve('tmdb_access_token'))->toBe('user-token');
+    });
+
+    it('falls back to the instance key when the user has none', function (): void {
+        $this->actingAs($this->user);
+
+        expect(ApiKey::resolve('tmdb_access_token'))->toBe('instance-token');
+    });
+
+    it('falls back to the instance key when unauthenticated (e.g. queue jobs)', function (): void {
+        expect(ApiKey::resolve('tmdb_access_token'))->toBe('instance-token');
+    });
+
+    it('ignores user keys and uses only the instance key under the shared policy', function (): void {
+        config()->set('api_keys.policy', 'shared');
+        $this->user->apiKeys()->create(['service' => 'tmdb_access_token', 'key' => 'user-token']);
+
+        $this->actingAs($this->user);
+
+        expect(ApiKey::resolve('tmdb_access_token'))->toBe('instance-token');
+    });
+
+    it('does not fall back to the instance key under the byo policy', function (): void {
+        config()->set('api_keys.policy', 'byo');
+        $this->actingAs($this->user);
+
+        expect(ApiKey::resolve('tmdb_access_token'))->toBeNull();
+    });
+
+    it('never resolves another user\'s key', function (): void {
+        $other = User::factory()->create();
+        $other->apiKeys()->create(['service' => 'tmdb_access_token', 'key' => 'other-token']);
+
+        $this->actingAs($this->user);
+
+        expect(ApiKey::resolve('tmdb_access_token'))->toBe('instance-token');
+    });
+
+    it('returns null for an unknown slug', function (): void {
+        expect(ApiKey::resolve('nonexistent.slug'))->toBeNull();
+    });
+});
+
+describe('ApiKeysForm', function (): void {
+    it('saves a key for the authenticated user', function (): void {
+        Livewire::actingAs($this->user)
+            ->test(ApiKeysForm::class)
+            ->set('inputs.tmdb_access_token', 'my-new-key')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        expect($this->user->fresh()->apiKeyFor('tmdb_access_token'))->toBe('my-new-key');
+    });
+
+    it('clears the input after saving so the full key is never re-rendered', function (): void {
+        Livewire::actingAs($this->user)
+            ->test(ApiKeysForm::class)
+            ->set('inputs.tmdb_access_token', 'my-new-key')
+            ->call('save')
+            ->assertSet('inputs.tmdb_access_token', '');
+    });
+
+    it('never renders a saved key in full, only a masked hint', function (): void {
+        $this->user->apiKeys()->create(['service' => 'tmdb_access_token', 'key' => 'abcdefabcdef1234']);
+
+        Livewire::actingAs($this->user)
+            ->test(ApiKeysForm::class)
+            ->assertDontSee('abcdefabcdef1234')
+            ->assertSee('••••1234');
+    });
+
+    it('removes a key', function (): void {
+        $this->user->apiKeys()->create(['service' => 'tmdb_access_token', 'key' => 'to-be-removed']);
+
+        Livewire::actingAs($this->user)
+            ->test(ApiKeysForm::class)
+            ->call('remove', 'tmdb_access_token');
+
+        expect($this->user->fresh()->apiKeyFor('tmdb_access_token'))->toBeNull();
+    });
+
+    it('does not persist keys under the shared policy', function (): void {
+        config()->set('api_keys.policy', 'shared');
+
+        Livewire::actingAs($this->user)
+            ->test(ApiKeysForm::class)
+            ->set('inputs.tmdb_access_token', 'blocked')
+            ->call('save');
+
+        expect($this->user->fresh()->apiKeyFor('tmdb_access_token'))->toBeNull();
+    });
+});
+
+it('cascade deletes keys when the user is deleted', function (): void {
+    $this->user->apiKeys()->create(['service' => 'tmdb_access_token', 'key' => 'k']);
+    $this->user->delete();
+
+    expect(UserApiKey::count())->toBe(0);
+});


### PR DESCRIPTION
Closes #36.

Lets each user optionally supply their own third-party API keys instead of relying solely on the shared `.env` keys. Fits the "own your instance, own your API access" philosophy.

## What's included
- **`user_api_keys` table** — `(user_id, service slug, encrypted key)`, unique per `(user, service)`, cascade-deleted with the user.
- **`UserApiKey` model** — encrypts on write / decrypts on read via `Crypt`. An undecryptable value (e.g. a rotated `APP_KEY`) returns `null` instead of throwing.
- **`App\Support\ApiKey::resolve()`** — central resolver used by every Saloon connector (TMDB, ComicVine, IGDB, BGG, Discogs, Setlist.fm, Trakt). Order: authenticated user's key → `config/services.php` (.env) → `null`. Always scoped to `Auth::user()`; a user can never resolve another user's key. Outside a request (queue jobs) it falls back to the instance key.
- **Admin policy** via `API_KEYS_POLICY`: `both` (default) | `shared` (env only, UI hidden) | `byo` (user keys only, no fallback).
- **IGDB** caches its Twitch OAuth token keyed by a hash of the resolved credentials, so per-user client IDs never reuse each other's token.
- **Settings UI** on the profile page (`ApiKeysForm` Livewire component): grouped by service, masked hint for a set key (`••••3f2a`), never echoes a full key, clears the input after save, per-key remove, honours the `shared` policy.
- `.env.example` documents the policy and the full set of service keys.

## Security
- Encrypted at rest (`Crypt`); a raw DB dump never exposes plaintext.
- Never rendered in full in the UI (masked hint only).
- Strictly scoped to `Auth::user()` — no `user_id` parameter anywhere.

## Verification
- 15 tests: encryption-at-rest, resolution across all three policies, cross-user isolation, decrypt-failure handling, cascade delete, and the Livewire save/remove/mask flows. Full suite green (109 passed).
- PHPStan (level max) clean, Pint clean.
- Screenshot-verified the settings UI (instance-key detection shows correctly for services configured in `.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)