### PR TITLE
fix(deploy): wait for teal-db instead of failing on a transient state

### DIFF
--- a/docker/deploy-prod.sh
+++ b/docker/deploy-prod.sh
@@ -22,6 +22,7 @@ TEAL_IMAGE="${TEAL_IMAGE:-ghcr.io/dotmavriq/teal}"
 TEAL_TAG="${TEAL_TAG:?TEAL_TAG (commit sha) must be set}"
 KEEP_BACKUPS="${KEEP_BACKUPS:-10}"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-120}"
+DB_WAIT_TIMEOUT="${DB_WAIT_TIMEOUT:-60}"
 COMPOSE="docker compose"
 
 export TEAL_IMAGE TEAL_TAG
@@ -44,8 +45,24 @@ log "Pre-flight checks (image: $IMAGE_REF)..."
 [ -f .env.production ] || fatal ".env.production missing in $PROJECT_DIR"
 docker network inspect web >/dev/null 2>&1 || fatal "Docker network 'web' missing"
 
-db_health="$(docker inspect --format '{{.State.Health.Status}}' teal-db 2>/dev/null || echo missing)"
-[ "$db_health" = "healthy" ] || fatal "teal-db is not healthy (status: $db_health) — aborting before touching anything"
+# Wait, rather than check once. A previous deploy that was *cancelled* mid-restart
+# (CI run cancelled, superseded push) can leave the stack recreating for a few
+# seconds. Failing instantly in that window makes a collision between deploys look
+# like a broken database or an unverifiable migration.
+db_health() { docker inspect --format '{{.State.Health.Status}}' teal-db 2>/dev/null || echo missing; }
+
+wait_for_db() {
+    local deadline=$((SECONDS + DB_WAIT_TIMEOUT))
+    local status
+    while :; do
+        status="$(db_health)"
+        [ "$status" = "healthy" ] && return 0
+        [ "$SECONDS" -ge "$deadline" ] && { echo "$status"; return 1; }
+        sleep 3
+    done
+}
+
+wait_for_db >/dev/null || fatal "teal-db not healthy after ${DB_WAIT_TIMEOUT}s (status: $(db_health)) — aborting before touching anything"
 log "  teal-db: healthy"
 
 # Capture the currently-running image so we can roll back to it.
@@ -84,6 +101,12 @@ $COMPOSE pull app queue
 # Render the SQL of pending migrations WITHOUT executing it, then scan for
 # data-destroying statements. Schema-only drops (index/constraint) are allowed.
 log "Scanning pending migrations for destructive statements..."
+
+# Re-check the database here, not just in pre-flight. Minutes may have passed
+# pulling the image, and this guard's failure mode is "abort the deploy" — so a
+# transient connection problem must not be reported as an unsafe migration.
+wait_for_db >/dev/null || fatal "teal-db not healthy before migration scan (status: $(db_health)) — aborting"
+
 PRETEND_SQL="$(docker run --rm \
     --network teal-internal \
     -e DB_HOST=db -e DB_PORT=5432 -e APP_ENV=production \


### PR DESCRIPTION
## Why

Production has been running `a6c05be` (Tailwind 4) since 2026-07-07, missing #57 (Vite 8) and #61 (per-user encrypted API keys). The deploy of `ce6c7a0` failed 19s in and nobody noticed — `main` has been red since.

Diagnosis (from backup timestamps, host image list and container state on gerty):

- `quality`, `tests`, `rector` all passed; only `Deploy to gerty` failed.
- The image built and pushed to GHCR fine, and **is** present on the host.
- Pre-flight passed and the DB backup completed (`teal-20260707-083549.sql.gz`, valid).
- That leaves the destructive-migration guard, which today passes on demand against the same image.

The migration it was guarding is purely additive:

```
create table "user_api_keys" (...)
alter table "user_api_keys" add constraint ... foreign key ...
alter table "user_api_keys" add constraint ... unique ...
```

Likely trigger: a **cancelled** CI run took its own backup at 08:33:46 and was killed mid-restart. The next run's guard ran ~90s later while the stack was still recreating, could not reach the database, and correctly refused to go live. Two deploys colliding, surfaced as an unverifiable migration.

## What changed

`concurrency: cancel-in-progress: false` prevents two deploys running at once, but nothing stops a *cancelled* deploy from leaving the box mid-apply and poisoning the next one.

- Pre-flight now waits up to `DB_WAIT_TIMEOUT` (60s, overridable) for `teal-db` instead of checking once.
- The same wait runs immediately before the migration scan. Minutes pass pulling the image, and that guard's failure mode is to abort the deploy — a transient connection problem must not masquerade as an unsafe migration.

A healthy database costs zero extra time.

## Not changed

The destructive-migration regex, no-backup-no-deploy, and the rollback path all behaved correctly and are untouched. The guard halting on something it could not verify was right; it just had a bad reason to be unable to verify.

## Verification

- `bash -n` clean.
- Wait loop unit-tested in isolation: returns immediately when healthy (no added latency), times out at exactly 60s when never healthy, and returns as soon as a delayed database comes up.
- Merging this triggers a fresh deploy that carries the hardening plus #57 and #61.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by waiting for the database to become healthy before continuing.
  * Added a configurable timeout for database readiness checks, defaulting to 60 seconds.
  * Rechecks database health before migration safety validation to reduce misleading deployment failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->